### PR TITLE
replace pyhive with impyla for warehouse connectivity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     },
     install_requires=[
         "dbt-core==1.1.0",
-        "setuptools>=40.3.0"
+        "setuptools>=40.3.0",
+        "impyla>=0.18a5"
     ]
 )


### PR DESCRIPTION
- replace pyhive with impyla for warehouse connectivity
- add impyla dependency

Internal Ticket: https://jira.cloudera.com/browse/DBT-172, 
https://jira.cloudera.com/browse/DBT-164, 
https://jira.cloudera.com/browse/DBT-183

Testplan:
use the following dbt profile:
<pre>
dbtproject:
 outputs:
  dev_hive:
     type: hive
     auth_type: LDAP
     user: [USER]
     password: [PASSWORD]
     schema: dbtproject
     host: [HOST from CDH settings]
     port: [PORT ususally 443 in case of LDAP]
     http_path: [HTTP Path from CDH settings]
     thread: 1
 target: dev_hive
</pre>

Run dbt debug (this should succeed for connectivity)