### PR TITLE
fix an issue where datetime field in seed file caused an error with impyla Cursor object.

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -8,14 +8,17 @@ from dbt.logger import GLOBAL_LOGGER as logger
 from dbt.utils import DECIMALS
 from dbt.adapters.hive import __version__
 
-from dbt.contracts.connection import AdapterResponse
+from dbt.contracts.connection import Connection, AdapterResponse
+
+from dbt.events.functions import fire_event
+from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 
 from datetime import datetime
 import sqlparams
 
 from hologram.helpers import StrEnum
 from dataclasses import dataclass, field
-from typing import Any, Optional, Dict
+from typing import Any, Optional, Dict, Tuple
 import base64
 import time
 
@@ -112,14 +115,14 @@ class HiveConnectionWrapper(object):
     def fetchone(self):
         return self._cursor.fetchone()
 
-    def execute(self, sql, bindings=None):
+    def execute(self, sql, bindings=None, configuration={}):
         if sql.strip().endswith(";"):
             sql = sql.strip()[:-1]
 
         if bindings is not None:
             bindings = [self._fix_binding(binding) for binding in bindings]
 
-        result = self._cursor.execute(sql,bindings)
+        result = self._cursor.execute(sql,bindings,configuration)
         return result
 
 
@@ -202,6 +205,46 @@ class HiveConnectionManager(SQLConnectionManager):
         return AdapterResponse(
             _message=message
         )
+
+    def add_query(
+        self,
+        sql: str,
+        auto_begin: bool = True,
+        bindings: Optional[Any] = None,
+        abridge_sql_log: bool = False
+    ) -> Tuple[Connection, Any]:
+        
+        connection = self.get_thread_connection()
+        if auto_begin and connection.transaction_open is False:
+            self.begin()
+        fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=connection.name))
+
+        with self.exception_handler(sql):
+            if abridge_sql_log:
+                log_sql = '{}...'.format(sql[:512])
+            else:
+                log_sql = sql
+
+            fire_event(SQLQuery(conn_name=connection.name, sql=log_sql))
+            pre = time.time()
+
+            cursor = connection.handle.cursor()
+
+            # paramstlye parameter is needed for the datetime object to be correctly qouted when
+            # running substitution query from impyla. this fix also depends on a patch for impyla:
+            # https://github.com/cloudera/impyla/pull/486
+            configuration = {}
+            configuration['paramstyle'] = 'format'
+            cursor.execute(sql, bindings, configuration)
+
+            fire_event(
+                SQLQueryStatus(
+                    status=str(self.get_response(cursor)),
+                    elapsed=round((time.time() - pre), 2)
+                )
+            )
+
+            return connection, cursor
 
     # No transactions on Hive....
     def add_begin_query(self, *args, **kwargs):


### PR DESCRIPTION
Internal Ticket: https://jira.cloudera.com/projects/DBT/issues/DBT-195

Testplan:
Make a seed file with and without date field, and run dbt seed before and after applying the PR.
seed file with date field should fail before the PR is applied, and should succeed afterwards.
A sample seed file:
<pre>
id,adapter,adapter_time_date
1,impala,2022-03-10T03:35:00
2,spark,2022-03-10T03:35:00
3,hive,2022-03-10T03:35:00
</pre>