### PR TITLE
fix an issue that caused object types to be wrongly classified as table when they were views

### DIFF
--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -155,8 +155,17 @@ class HiveAdapter(SQLAdapter):
         #        )
         #    )
 
-        relations = []
+        # in Hive 2, result_tables has table + view, result_views only has views
+        # so we build a result_tables_without_view that doesnot have views
+        
+        result_tables_without_view = []
         for row in result_tables:
+            # check if this table is view
+            is_view = len(list(filter(lambda x: x['tab_name'] == row['tab_name'], result_views))) == 1
+            if (not is_view): result_tables_without_view.append(row)
+		
+        relations = []
+        for row in result_tables_without_view:
             relations.append(
                 self.Relation.create(
                     schema=schema_relation.schema,
@@ -172,6 +181,7 @@ class HiveAdapter(SQLAdapter):
                     type='view'
                 )
             )
+
         return relations
 
 


### PR DESCRIPTION
fix an issue that caused object types to be wrongly classified as table when they were views.

Hive 2's show view returns only views , but show tables returns both tables and views. This PR separates the table and view objects as needed by dbt. 

Internal Ticket: https://jira.cloudera.com/browse/DBT-196

Testplan:
All functional tests except TestIncrementalHive.test_incremental should pass.
To run the functional tests use the following:
python3 -m pytest tests/functional