### PR TITLE
DBT-225 fix for extra quotes added to strings

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -149,8 +149,6 @@ class HiveConnectionWrapper(object):
             return float(value)
         elif isinstance(value, datetime):
             return value.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]
-        elif isinstance(value, str):
-            return "'{}'".format(value.replace("'", "''"))
         else:
             return value
 
@@ -173,7 +171,7 @@ class HiveConnectionManager(SQLConnectionManager):
         # add configuration to yaml
         if (not credentials.auth_type):
            hive_conn = impala.dbapi.connect(
-                         host=credentials.host, 
+                         host=credentials.host,
                          port=credentials.port
                    )
         elif (credentials.auth_type.upper() == 'LDAP'):
@@ -226,7 +224,7 @@ class HiveConnectionManager(SQLConnectionManager):
         bindings: Optional[Any] = None,
         abridge_sql_log: bool = False
     ) -> Tuple[Connection, Any]:
-        
+
         connection = self.get_thread_connection()
         if auto_begin and connection.transaction_open is False:
             self.begin()


### PR DESCRIPTION
Our impyla driver takes care of properly reading strings. Adding quotes manually is not necessary.

Tested with dbt seed and manual testing

![image](https://user-images.githubusercontent.com/2308360/186448017-1c1ad174-048e-4d1a-a20c-bfa8da1d68df.png)

DDbt test cases that were failing earlier now passes
![image](https://user-images.githubusercontent.com/2308360/186448195-ea8b856a-d8a8-4586-b31f-250727603d96.png)
