### PR TITLE
add grants support for dbt-core=1.2

### DIFF
--- a/dbt/include/hive/macros/apply_grants.sql
+++ b/dbt/include/hive/macros/apply_grants.sql
@@ -1,0 +1,35 @@
+{#
+# Copyright 2022 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+{#-- Assume grants copy over --#}
+{% macro hive__copy_grants() %}
+    {{ return(True) }}
+{% endmacro %}
+
+{%- macro hive__get_grant_sql(relation, privilege, grantees) -%}
+    grant {{ privilege }} on {{ relation }} to {{ grantees | join(', ') }}
+{%- endmacro %}
+
+{%- macro hive__get_revoke_sql(relation, privilege, grantees) -%}
+    revoke {{ privilege }} on {{ relation }} from {{ grantees | join(', ') }}
+{%- endmacro %}
+
+{#-- Hive supports multiple grantees per dcl statement --#}
+{%- macro hive__support_multiple_grantees_per_dcl_statement() -%}
+    {{ return(True) }}
+{%- endmacro -%}
+
+

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -13,6 +13,8 @@ from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
 from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
+from dbt.tests.adapter.grants.base_grants import BaseGrants
+
 
 class TestSimpleMaterializationsHive(BaseSimpleMaterializations):
    pass
@@ -53,4 +55,7 @@ class TestGenericTestsHive(BaseGenericTests):
 #
 
 class TestBaseAdapterMethod(BaseAdapterMethod):
+    pass
+
+class TestBaseGrantsHive(BaseGrants):
     pass


### PR DESCRIPTION
- add grants support
- add TestBaseGrantsHive in fuctional test

TestPlan:
- ensure dbt-core==1.2.x is installed
- Run the functional test:
python3 -m pytest tests/functional -k 'TestBaseGrantsHive'

This should succeed.