### PR TITLE
fix an issue that prevented connection to local hive instance

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -180,7 +180,8 @@ class HiveConnectionManager(SQLConnectionManager):
             if (not credentials.auth_type):
                 hive_conn = impala.dbapi.connect(
                                 host=credentials.host, 
-                                port=credentials.port
+                                port=credentials.port,
+                                auth_mechanism='PLAIN'       
                         )
             elif (credentials.auth_type.upper() == 'LDAP'):
                 auth_type = "ldap"


### PR DESCRIPTION
Pass auth_mechanism='PLAIN' when connecting to local Hive instance, without this the connection fails for a local unsecured setup.

Testplan:
- Setup local hive instance (for insance use this docker image: https://github.com/big-data-europe/docker-hive)
- Test dbt debug using profile:
<pre>
  dev_hive_local:
     type: hive
     host: localhost
     port: 10000
     schema: dbtdemo
</pre>