### PR TITLE
Use Hive version to determine if merge is supported

### DIFF
--- a/dbt/include/hive/macros/adapters.sql
+++ b/dbt/include/hive/macros/adapters.sql
@@ -242,7 +242,6 @@
   {% endif %}
 {% endmacro %}
 
-
 {% macro hive__list_tables_without_caching(schema) %}
   {% call statement('list_tables_without_caching', fetch_result=True) -%}
     show tables in {{ schema }}
@@ -258,4 +257,20 @@
   {% endcall %}
   {% do return(load_result('list_views_without_caching').table) %}
 {% endmacro %}
-k
+
+{% macro get_hive_version() %}
+  {% set version_results = run_query('select version()') %}
+  {% if execute %}
+     {% set num_rows = (version_results | length) %}
+
+     {% if num_rows == 1 %}
+        {% set version_text = version_results[0][0] %}
+        {{ log("get_hive_version " ~ version_text) }}
+        {% do return(version_text.split(".")[0]) %}
+     {% else %}
+        {% do return('2') %}  {# assume hive 2 by default #}    
+     {% endif %}
+  {% else %}
+    {% do return('2') %}  {# assume hive 2 by default #}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/hive/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/hive/macros/materializations/incremental/incremental.sql
@@ -16,9 +16,18 @@
 
 {% materialization incremental, adapter='hive' -%}
   
+  {% set hive_version = get_hive_version() | int %}
+  {{ log("HIVE VERSION " ~ hive_version) }}
+
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
   {%- set raw_file_format = config.get('file_format', default='parquet') -%}
   {%- set raw_strategy = config.get('incremental_strategy', default='append') -%}
+
+  {#-- support merge in only Hive 3 --#}
+  {% if (hive_version < 3 and raw_strategy == 'merge') %}
+    {% do exceptions.raise_compiler_error("incremental_strategy='merge' is only supported in Hive 3") %}
+    {{ return(None) }}
+  {% endif %}
   
   {%- set file_format = dbt_hive_validate_get_file_format(raw_file_format) -%}
   {%- set strategy = dbt_hive_validate_get_incremental_strategy(raw_strategy, file_format) -%}


### PR DESCRIPTION
Add a macro to get the Hive version to determine if the incremental merge is supported by warehouse.

The PR will check the Hive version for an incremental merge run and if the version is not 3, will fail.