### PR TITLE
Add http error identification for credentials and hostname errors

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -229,9 +229,11 @@ class HiveConnectionManager(SQLConnectionManager):
         try:
             yield
         except HttpError as httpError:
-            print ("HTTP Authorization error: " + str(httpError))
+            logger.debug("Authorization error: {}".format(httpError))
+            raise dbt.exceptions.RuntimeException ("HTTP Authorization error: " + str(httpError) + ", please check your credentials")
         except HiveServer2Error as hiveError:
-            print("Hive server connection error: " + str(hiveError))
+            logger.debug("Server connection error: {}".format(hiveError))
+            raise dbt.exceptions.RuntimeException ("Unable to establish connection to Hive server: " + str(hiveError))
         except Exception as exc:
             logger.debug("Error while running:\n{}".format(sql))
             logger.debug(exc)

--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -35,6 +35,8 @@ import base64
 import time
 
 import impala.dbapi
+from impala.error import HttpError
+from impala.error import HiveServer2Error
 
 import json
 import hashlib
@@ -226,6 +228,10 @@ class HiveConnectionManager(SQLConnectionManager):
     def exception_handler(self, sql: str):
         try:
             yield
+        except HttpError as httpError:
+            print ("HTTP Authorization error: " + str(httpError))
+        except HiveServer2Error as hiveError:
+            print("Hive server connection error: " + str(hiveError))
         except Exception as exc:
             logger.debug("Error while running:\n{}".format(sql))
             logger.debug(exc)


### PR DESCRIPTION
Internal ticket: https://jira.cloudera.com/browse/DBT-372

The error printed seems to be generic, so adding
code to identity the failure from Hive connection.

Test plan:
  * Move into a dbt hive project and install dbt-hive from this git repo
  * Add profile details in your home dbt file like below, 
  dbt_hive_demo:
    outputs:
      dev_cia_cdp:
        auth_type: ldap
        host: {}
        http_path: {}
        password: {}
        port: 443
        schema: dbt_hive_demo
        threads: 4
        type: hive
        use_http_transport: true
        use_ssl: true
        user: {}
    target: dev_cia_cdp
  * Update with wrong hostname or wrong user credentials
  * run > dbt debug, and you should see the type of error in the console
  * Add below snowplow configs to your .env if you face any snowplow error SNOWPLOW_ENDPOINT=https://dcevents.cldrteam.datacoral.io/cldrteam/apievents
SNOWPLOW_TIMEOUT=10
SNOWPLOW_API_KEY=<your_key>
SNOWPLOW_ENNV=prod

Signed-off-by: Sanjeev kumar N <sanjeevitcit@gmail.com>