### PR TITLE
Add query instrumentation

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
+import json
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -251,11 +252,31 @@ class HiveConnectionManager(SQLConnectionManager):
             self.begin()
         fire_event(ConnectionUsed(conn_type=self.TYPE, conn_name=connection.name))
 
+        additional_info = {}
+        if self.query_header:
+            try:
+                additional_info = json.loads(self.query_header.comment.query_comment.strip())
+            except Exception as ex:  # silently ignore error for parsing
+                additional_info = {}
+                logger.debug(f"Unable to get query header {ex}")
+
         with self.exception_handler(sql):
             if abridge_sql_log:
                 log_sql = "{}...".format(sql[:512])
             else:
                 log_sql = sql
+
+            # track usage
+            payload = {
+                "event_type": "dbt_hive_start_query",
+                "sql": log_sql,
+                "profile_name": self.profile.profile_name
+            }
+
+            for key, value in additional_info.items():
+                payload[key] = value
+
+            tracker.track_usage(payload)
 
             fire_event(SQLQuery(conn_name=connection.name, sql=log_sql))
             pre = time.time()
@@ -265,13 +286,36 @@ class HiveConnectionManager(SQLConnectionManager):
             # paramstyle parameter is needed for the datetime object to be correctly quoted when
             # running substitution query from impyla. this fix also depends on a patch for impyla:
             # https://github.com/cloudera/impyla/pull/486
-            configuration = {"paramstyle": "format"}
-            cursor.execute(sql, bindings, configuration)
+            
+            query_exception = None
+            try:
+                configuration = {"paramstyle": "format"}
+                cursor.execute(sql, bindings, configuration)
+                query_status = str(self.get_response(cursor))
+            except Exception as ex:
+                query_status = str(ex)
+                query_exception = ex
+
+            elapsed_time = time.time() - pre
+
+            payload = {
+                "event_type": "dbt_hive_end_query",
+                "sql": log_sql,
+                "elapsed_time": "{:.2f}".format(elapsed_time),
+                "status": query_status,
+                "profile_name": self.profile.profile_name
+            }
+
+            tracker.track_usage(payload)
+
+            # re-raise query exception so that it propogates to dbt
+            if (query_exception):
+                raise query_exception
 
             fire_event(
                 SQLQueryStatus(
                     status=str(self.get_response(cursor)),
-                    elapsed=round((time.time() - pre), 2),
+                    elapsed=round(elapsed_time, 2),
                 )
             )
 


### PR DESCRIPTION
## Describe your changes
Add query instrumentation.
Capture query_type, query_status, elapsed_time (for query execution) 

## Ticket
Internal: https://jira.cloudera.com/browse/DBT-386

## Testing procedure
With a dbt debug, check the output in logs/dbt.log, there should be an entry similar to:

(for query start)
06:41:59.880807 [debug] [Thread-1  ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_hive_start_query", "profile_name": "dbtdemo", "sql_type": "select 1", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "id": "3fae327d-2a42-4fb9-9106-db9a05b51e85", "unique_host_hash": "cd2782200d6326126da659d53c3dfe44", "unique_user_hash": "3d23971613757087a31726e1b95f7b57", "unique_session_hash": "e4445edb8add784de4c6f27286d55055", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "hive-1.1.3"}}]

(for query end - success)
06:42:20.490056 [debug] [Thread-2  ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_hive_end_query", "elapsed_time": "20.61", "status": "OK", "profile_name": "dbtdemo", "sql_type": "select 1", "auth": "N/A", "connection_state": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "id": "3fae327d-2a42-4fb9-9106-db9a05b51e85", "unique_host_hash": "cd2782200d6326126da659d53c3dfe44", "unique_user_hash": "3d23971613757087a31726e1b95f7b57", "unique_session_hash": "e4445edb8add784de4c6f27286d55055", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "hive-1.1.3"}}]

(for query end - error)
06:01:34.447610 [debug] [Thread-14 ]: Tracker adapter: Sending Event [{"data": {"event_type": "dbt_hive_end_query", "elapsed_time": "40.20", "status": "Error while compiling statement: FAILED: SemanticException org.apache.hadoop.hive.ql.parse.SemanticException: Table already exists: dbtdemo.my_first_dbt_model", "profile_name": "dbtdemo", "sql_type": "create table", "auth": "N/A", "connection_state": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "id": "52fd68d1-27ff-4c46-ab7c-4c1340e56156", "unique_host_hash": "cd2782200d6326126da659d53c3dfe44", "unique_user_hash": "3d23971613757087a31726e1b95f7b57", "unique_session_hash": "cf1b678acc195a615ac5c1116e54e596", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.1.2", "dbt_adapter": "hive-1.1.3"}}]

## Checklist for review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow peop-8 standards
- [X] I have checked suggestions from pylint to make sure code is of good quality