### PR TITLE
functional tests fixes for 1.2 migration 

### DIFF
--- a/dbt/adapters/hive/cloudera_tracking.py
+++ b/dbt/adapters/hive/cloudera_tracking.py
@@ -92,7 +92,12 @@ def populate_unique_ids(cred: Credentials):
     timestamp = str(time.time()).encode()
 
     # dbt invocation id
-    unique_ids["id"] = active_user.invocation_id
+    # dbt invocation id
+    if active_user:
+       unique_ids["id"] = active_user.invocation_id
+    else:
+       unique_ids["id"] = "N/A"
+
     # hashed host name
     unique_ids["unique_host_hash"] = hashlib.md5(host).hexdigest()
     # hashed username

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,21 +10,18 @@ pytest_plugins = ["dbt.tests.fixtures.project"]
 @pytest.fixture(scope="class")
 def dbt_profile_target():
     return {
-        # 'type': 'trino',
-        # 'database': 'hive',
-        # 'port': 443,
-        # 'threads': 1,
-        # 'auth': 'LDAP',
-        # 'method': 'ldap',
-        # 'host': 'trino.d4b.jp',
-        # 'user': os.getenv('TRINO_USER'),
-        # 'password': os.getenv('TRINO_PASSWORD'),
-        'threads': 1,
         'type': 'hive',
-        'host': '172.31.0.16',
-        'auth': 'LDAP',
-        'user': os.getenv('HIVE_USER'),
+        'threads': 4,
+        'schema': 'dbt_hive_adapter_test',
+        'host':  os.getenv('HIVE_HOST'),
+        'http_path': os.getenv('HIVE_HTTP_PATH'),
+        'port': int(os.getenv('HIVE_PORT')),
+        'auth_type': 'LDAP',
+        'use_http_transport': True,
+        'use_ssl': True,
+        'username': os.getenv('HIVE_USER'),
         'password': os.getenv('HIVE_PASSWORD'),
+        'threads': 4,
     }
 
 # 


### PR DESCRIPTION
## Describe your changes
* fix an issue with instrumentation that caused functional test to fail
* change hive functional test to be easily modified

## Testing procedure/screenshots(if appropriate):
run functional test: 
python -m pytest tests/functional/adapter/test_basic.py

this should pass all the tests as:
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 7 items

tests/functional/adapter/test_basic.py .......                           [100%]


