### PR TITLE
Changes to support list aggregation macro

### DIFF
--- a/dbt/include/hive/macros/utils/listagg.sql
+++ b/dbt/include/hive/macros/utils/listagg.sql
@@ -1,0 +1,17 @@
+{% macro hive__listagg(measure, delimiter_text, order_by_clause, limit_num) -%}
+
+  {% if order_by_clause %}
+    {{ exceptions.warn("order_by_clause is not supported for listagg on Hive") }}
+  {% endif %}
+
+  {% if limit_num %}
+    {{ exceptions.warn("limit_num is not supported for listagg on Hive") }}
+  {% endif %}
+
+  {% set collected_list %} collect_list({{ measure }}) {% endset %}
+
+  {% set final %} concat_ws({{ delimiter_text }}, {{ collected_list }}) {% endset %}
+
+  {% do return(final) %}
+
+{%- endmacro %}


### PR DESCRIPTION
## Describe your changes
Support for list agregation macro
## Internal Jira ticket number or external issue link

## Testing procedure/screenshots(if appropriate):
(venv_hive) spulapura@Sujits-MacBook-Pro dbt-hive % python -m pytest tests/functional/adapter/test_utils.py -k "TestListAgg"
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.10.7, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/spulapura/DBT_HIVE/dbt-hive-migration/dbt-hive
collected 19 items / 18 deselected / 1 selected

tests/functional/adapter/test_utils.py .                                                                                                                                               [100%]

====================================================================================== warnings summary ======================================================================================
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
  <template>:34: DeprecationWarning: 'soft_unicode' has been renamed to 'soft_str'. The old name will be removed in MarkupSafe 2.1.

tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
tests/functional/adapter/test_utils.py::TestListagg::test_build_assert_equal
  /Users/spulapura/DBT_HIVE/venv_hive/lib/python3.10/site-packages/jinja2/runtime.py:679: DeprecationWarning: 'soft_unicode' has been renamed to 'soft_str'. The old name will be removed in MarkupSafe 2.1.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 1 passed, 18 deselected, 7 warnings in 95.71s (0:01:35) ================================================================