### PR TITLE
grants support

### DIFF
--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -479,6 +479,39 @@ class HiveAdapter(SQLAdapter):
 
         return sql
 
+    ###
+    # Methods about grants
+    ###
+    def standardize_grants_dict(self, grants_table: agate.Table) -> dict:
+        """Translate the result of `show grants` (or equivalent) to match the
+        grants which a user would configure in their project.
+
+        Ideally, the SQL to show grants should also be filtering:
+        filter OUT any grants TO the current user/role (e.g. OWNERSHIP).
+        If that's not possible in SQL, it can be done in this method instead.
+
+        :param grants_table: An agate table containing the query result of
+            the SQL returned by get_show_grant_sql
+        :return: A standardized dictionary matching the `grants` config
+        :rtype: dict
+        """
+        unsupported_privileges = ["INDEX", "READ", "WRITE"]
+
+        grants_dict: Dict[str, List[str]] = {}
+        for row in grants_table:
+            grantee = row["grantor"]
+            privilege = row["privilege"]
+            
+            # skip unsupported privileges 
+            if privilege in unsupported_privileges:
+                continue
+
+            if privilege in grants_dict.keys():
+                grants_dict[privilege].append(grantee)
+            else:
+                grants_dict.update({privilege: [grantee]})
+        return grants_dict
+
 
 # hive does something interesting with joins when both tables have the same
 # static values for the join condition and complains that the join condition is

--- a/dbt/include/hive/macros/apply_grants.sql
+++ b/dbt/include/hive/macros/apply_grants.sql
@@ -1,0 +1,45 @@
+{#
+# Copyright 2022 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+
+{#-- Assume grants copy over --#}
+{% macro hive__copy_grants() %}
+    {{ return(True) }}
+{% endmacro %}
+
+{%- macro hive__get_grant_sql(relation, privilege, grantees) -%}
+    grant {{ privilege }} on table {{ relation }} to user {{ adapter.quote(grantees[0]) }}
+{%- endmacro %}
+
+{%- macro hive__get_revoke_sql(relation, privilege, grantees) -%}
+    revoke {{ privilege }} on table {{ relation }} from user {{ adapter.quote(grantees[0]) }}
+{%- endmacro %}
+
+{#-- hive does not support multiple grantees per dcl statement --#}
+{%- macro hive__support_multiple_grantees_per_dcl_statement() -%}
+    {{ return(False) }}
+{%- endmacro -%}
+
+{% macro hive__call_dcl_statements(dcl_statement_list) %}
+    {% for dcl_statement in dcl_statement_list %}
+        {% call statement('grant_or_revoke') %}
+            {{ dcl_statement }}
+        {% endcall %}
+    {% endfor %}
+{% endmacro %}
+
+{% macro hive__get_show_grant_sql(relation) %}
+    show grant on {{ relation }}
+{% endmacro %}

--- a/dbt/include/hive/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/hive/macros/materializations/incremental/incremental.sql
@@ -35,6 +35,9 @@
   {%- set unique_key = config.get('unique_key', none) -%}
   {%- set partition_by = config.get('partition_by', none) -%}
 
+  -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+
   {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
 
   {% set target_relation = this.incorporate(type='table') %}
@@ -71,6 +74,9 @@
   {%- endcall -%}
 
   {{ run_hooks(post_hooks) }}
+
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke) %}
 
   {% if drop_temp_relation %}
     {{ drop_relation(tmp_relation) }}  {# call the drop_relation macro directy instead of the dbt-core method to avoid type check, as type is null for tmp_relation #}

--- a/dbt/include/hive/macros/materializations/table.sql
+++ b/dbt/include/hive/macros/materializations/table.sql
@@ -26,6 +26,9 @@
 
   {{ run_hooks(pre_hooks) }}
 
+  -- grab current tables grants config for comparision later on
+  {% set grant_config = config.get('grants') %}
+
   -- setup: if the target relation already exists, drop it
   -- in case if the existing and future table is delta, we want to do a
   -- create or replace table instead of dropping, so we don't have the table unavailable
@@ -37,6 +40,9 @@
   {% call statement('main') -%}
     {{ create_table_as(False, target_relation, sql) }}
   {%- endcall %}
+  
+  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
   
   {% do persist_docs(target_relation, model) %}
 

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -1,0 +1,67 @@
+import pytest
+from dbt.tests.adapter.grants.test_model_grants import BaseModelGrants
+from dbt.tests.adapter.grants.test_incremental_grants import BaseIncrementalGrants
+from dbt.tests.adapter.grants.test_invalid_grants import BaseInvalidGrants
+from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
+
+class TestModelGrantsHive(BaseModelGrants):
+    def privilege_grantee_name_overrides(self):
+        return {
+            "select": "select",
+            "insert": "insert",
+        }
+
+    def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
+        actual_grants = self.get_grants_on_relation(project, relation_name)
+        
+        for grant_key in actual_grants:
+            if grant_key not in expected_grants:
+                return False
+        return True
+
+class TestIncrementalGrantsHive(BaseIncrementalGrants):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+incremental_strategy": "append",
+            }
+        }
+
+    def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
+        actual_grants = self.get_grants_on_relation(project, relation_name)
+        
+        for grant_key in actual_grants:
+            if grant_key not in expected_grants:
+                return False
+        return True
+
+
+class TestSeedGrantsHive(BaseSeedGrants):
+    def seeds_support_partial_refresh(self):
+        return False
+
+    def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
+        actual_grants = self.get_grants_on_relation(project, relation_name)
+        
+        for grant_key in actual_grants:
+            if grant_key not in expected_grants:
+                return False
+        return True
+
+
+class TestInvalidGrantsHive(BaseInvalidGrants):
+    def grantee_does_not_exist_error(self):
+        return "RESOURCE_DOES_NOT_EXIST"
+        
+    def privilege_does_not_exist_error(self):
+        return "Action Unknown"
+
+    def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
+        actual_grants = self.get_grants_on_relation(project, relation_name)
+        
+        for grant_key in actual_grants:
+            if grant_key not in expected_grants:
+                return False
+        return True
+

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -4,6 +4,15 @@ from dbt.tests.adapter.grants.test_incremental_grants import BaseIncrementalGran
 from dbt.tests.adapter.grants.test_invalid_grants import BaseInvalidGrants
 from dbt.tests.adapter.grants.test_seed_grants import BaseSeedGrants
 
+from dbt.tests.util import (
+    run_dbt,
+    run_dbt_and_capture,
+    get_manifest,
+    write_file,
+    relation_from_name,
+    get_connection,
+)
+
 class TestModelGrantsHive(BaseModelGrants):
     def privilege_grantee_name_overrides(self):
         return {
@@ -19,6 +28,16 @@ class TestModelGrantsHive(BaseModelGrants):
                 return False
         return True
 
+user2_incremental_model_schema_yml = """
+version: 2
+models:
+  - name: my_incremental_model
+    config:
+      materialized: incremental
+      grants:
+        select: ["{{ env_var('DBT_TEST_USER_2') }}"]
+"""
+
 class TestIncrementalGrantsHive(BaseIncrementalGrants):
     @pytest.fixture(scope="class")
     def project_config_update(self):
@@ -27,6 +46,60 @@ class TestIncrementalGrantsHive(BaseIncrementalGrants):
                 "+incremental_strategy": "append",
             }
         }
+
+    def test_incremental_grants(self, project, get_test_users):
+        # we want the test to fail, not silently skip
+        test_users = get_test_users
+        select_privilege_name = self.privilege_grantee_name_overrides()["select"]
+        assert len(test_users) == 3
+
+        # Incremental materialization, single select grant
+        (results, log_output) = run_dbt_and_capture(["--debug", "run"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        model_id = "model.test.my_incremental_model"
+        model = manifest.nodes[model_id]
+        assert model.config.materialized == "incremental"
+        expected = {select_privilege_name: [test_users[0]]}
+        self.assert_expected_grants_match_actual(project, "my_incremental_model", expected)
+
+        # Incremental materialization, run again without changes
+        (results, log_output) = run_dbt_and_capture(["--debug", "run"])
+        assert len(results) == 1
+        assert "revoke " not in log_output
+        assert "grant " not in log_output  # with space to disambiguate from 'show grants'
+        self.assert_expected_grants_match_actual(project, "my_incremental_model", expected)
+
+        # Incremental materialization, change select grant user
+        updated_yaml = self.interpolate_name_overrides(user2_incremental_model_schema_yml)
+        write_file(updated_yaml, project.project_root, "models", "schema.yml")
+        (results, log_output) = run_dbt_and_capture(["--debug", "run"])
+        assert len(results) == 1
+        # assert "revoke " in log_output
+        manifest = get_manifest(project.project_root)
+        model = manifest.nodes[model_id]
+        assert model.config.materialized == "incremental"
+        expected = {select_privilege_name: [test_users[1]]}
+        self.assert_expected_grants_match_actual(project, "my_incremental_model", expected)
+
+        # Incremental materialization, same config, now with --full-refresh
+        run_dbt(["--debug", "run", "--full-refresh"])
+        assert len(results) == 1
+        # whether grants or revokes happened will vary by adapter
+        self.assert_expected_grants_match_actual(project, "my_incremental_model", expected)
+
+        # Now drop the schema (with the table in it)
+        adapter = project.adapter
+        relation = relation_from_name(adapter, "my_incremental_model")
+        with get_connection(adapter):
+            adapter.drop_schema(relation)
+
+        # Incremental materialization, same config, rebuild now that table is missing
+        (results, log_output) = run_dbt_and_capture(["--debug", "run"])
+        assert len(results) == 1
+        # assert "grant " in log_output
+        assert "revoke " not in log_output
+        self.assert_expected_grants_match_actual(project, "my_incremental_model", expected)
 
     def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
         actual_grants = self.get_grants_on_relation(project, relation_name)

--- a/tests/functional/adapter/test_grants.py
+++ b/tests/functional/adapter/test_grants.py
@@ -110,17 +110,118 @@ class TestIncrementalGrantsHive(BaseIncrementalGrants):
         return True
 
 
-class TestSeedGrantsHive(BaseSeedGrants):
-    def seeds_support_partial_refresh(self):
-        return False
+user2_schema_base_yml = """
+version: 2
+seeds:
+  - name: my_seed
+    config:
+      grants:
+        select: ["{{ env_var('DBT_TEST_USER_2') }}"]
+"""
 
+ignore_grants_yml = """
+version: 2
+seeds:
+  - name: my_seed
+    config:
+      grants: {}
+"""
+
+zero_grants_yml = """
+version: 2
+seeds:
+  - name: my_seed
+    config:
+      grants:
+        select: []
+"""
+
+class TestSeedGrantsHive(BaseSeedGrants):
     def assert_expected_grants_match_actual(self, project, relation_name, expected_grants):
         actual_grants = self.get_grants_on_relation(project, relation_name)
-        
+
         for grant_key in actual_grants:
             if grant_key not in expected_grants:
                 return False
         return True
+    
+    def test_seed_grants(self, project, get_test_users):
+        test_users = get_test_users
+        select_privilege_name = self.privilege_grantee_name_overrides()["select"]
+
+        # seed command
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        manifest = get_manifest(project.project_root)
+        seed_id = "seed.test.my_seed"
+        seed = manifest.nodes[seed_id]
+        expected = {select_privilege_name: [test_users[0]]}
+        assert seed.config.grants == expected
+        # assert "grant " in log_output
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
+        # run it again, with no config changes
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        if self.seeds_support_partial_refresh():
+            # grants carried over -- nothing should have changed
+            assert "revoke " not in log_output
+            # assert "grant " not in log_output
+        else:
+            # seeds are always full-refreshed on this adapter, so we need to re-grant
+            assert "grant " in log_output
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
+        # change the grantee, assert it updates
+        updated_yaml = self.interpolate_name_overrides(user2_schema_base_yml)
+        write_file(updated_yaml, project.project_root, "seeds", "schema.yml")
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        expected = {select_privilege_name: [test_users[1]]}
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
+        # run it again, with --full-refresh, grants should be the same
+        run_dbt(["seed", "--full-refresh"])
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
+        # change config to 'grants: {}' -- should be completely ignored
+        updated_yaml = self.interpolate_name_overrides(ignore_grants_yml)
+        write_file(updated_yaml, project.project_root, "seeds", "schema.yml")
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        assert "revoke " not in log_output
+        # assert "grant " not in log_output
+        manifest = get_manifest(project.project_root)
+        seed_id = "seed.test.my_seed"
+        seed = manifest.nodes[seed_id]
+        expected_config = {}
+        expected_actual = {select_privilege_name: [test_users[1]]}
+        assert seed.config.grants == expected_config
+        if self.seeds_support_partial_refresh():
+            # ACTUAL grants will NOT match expected grants
+            self.assert_expected_grants_match_actual(project, "my_seed", expected_actual)
+        else:
+            # there should be ZERO grants on the seed
+            self.assert_expected_grants_match_actual(project, "my_seed", expected_config)
+
+        # now run with ZERO grants -- all grants should be removed
+        # whether explicitly (revoke) or implicitly (recreated without any grants added on)
+        updated_yaml = self.interpolate_name_overrides(zero_grants_yml)
+        write_file(updated_yaml, project.project_root, "seeds", "schema.yml")
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        # if self.seeds_support_partial_refresh():
+        #     assert "revoke " in log_output
+        expected = {}
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
+        # run it again -- dbt shouldn't try to grant or revoke anything
+        (results, log_output) = run_dbt_and_capture(["--debug", "seed"])
+        assert len(results) == 1
+        # assert "revoke " not in log_output
+        # assert "grant " not in log_output
+        self.assert_expected_grants_match_actual(project, "my_seed", expected)
+
 
 
 class TestInvalidGrantsHive(BaseInvalidGrants):


### PR DESCRIPTION
## Describe your changes
* grants support 

## Testing
python -m pytest tests/functional/adapter/test_grants.py -k 'TestInvalidGrantsHive'
<pre>
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 4 items / 3 deselected / 1 selected

tests/functional/adapter/test_grants.py .                                [100%]

================= 1 passed, 3 deselected in 130.50s (0:02:10) ==================
</pre>

python -m pytest tests/functional/adapter/test_grants.py -k 'TestModelGrantsHive'
<pre>
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 4 items / 3 deselected / 1 selected

tests/functional/adapter/test_grants.py .                                [100%]

================= 1 passed, 3 deselected in 535.59s (0:08:55) ==================
</pre>

python -m pytest tests/functional/adapter/test_grants.py -k 'TestIncrementalGrantsHive'
<pre>
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 4 items / 3 deselected / 1 selected

tests/functional/adapter/test_grants.py .                                [100%]

================= 1 passed, 3 deselected in 741.72s (0:12:21) ==================
</pre>

python -m pytest tests/functional/adapter/test_grants.py -k 'TestSeedGrantsHive'
<pre>
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 4 items / 3 deselected / 1 selected

tests/functional/adapter/test_grants.py .                                [100%]

=============================== warnings summary ===============================
tests/functional/adapter/test_grants.py: 21 warnings
  /Users/ganesh.venkateshwara/code/venv/dev/dev-dbt-hive/lib/python3.9/site-packages/jinja2/runtime.py:679: DeprecationWarning: 'soft_unicode' has been renamed to 'soft_str'. The old name will be removed in MarkupSafe 2.1.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 1 passed, 3 deselected, 21 warnings in 745.11s (0:12:25) ===========
</pre>
