### PR TITLE
fix and issue when using dbt seed with number values of 0 would get converted to NULL

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -351,7 +351,7 @@ class HiveConnectionManager(SQLConnectionManager):
 
             if bindings:
                 # to avoid None as being treated as string, convert it to empty string
-                bindings = map(lambda x: x if x else "", bindings)
+                bindings = list(map(lambda x: x if x else x if x != None and len(str(x)) > 0 else "", bindings))
 
             query_exception = None
             try:


### PR DESCRIPTION
Tested with macros that caused this error:

<pre>
(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt-hive % python -m pytest tests/functional/adapter/test_utils.py -k 'TestConcat' 
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 20 items / 19 deselected / 1 selected                                                                                                                                              

tests/functional/adapter/test_utils.py .                                                                                                                                               [100%]
</pre>

<pre>
(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt-hive % python -m pytest tests/functional/adapter/test_utils.py -k 'TestCastBoolToText' 
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 20 items / 19 deselected / 1 selected                                                                                                                                              

tests/functional/adapter/test_utils.py .                                                                                                                                               [100%]
</pre>

<pre>
(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt-hive % python -m pytest tests/functional/adapter/test_utils.py -k 'TestHash'           
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 20 items / 19 deselected / 1 selected                                                                                                                                              

tests/functional/adapter/test_utils.py .                                                                                                                                               [100%]
</pre>