### PR TITLE
add hive__get_incremental_default_sql() macro

### DIFF
--- a/dbt/include/hive/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/hive/macros/materializations/incremental/strategies.sql
@@ -100,3 +100,10 @@
   {%- endif -%}
 
 {% endmacro %}
+
+
+{% macro hive__get_incremental_default_sql(arg_dict) %}
+  {#-- default mode is append, so return the sql for the same  #}  
+  {% do return(get_insert_into_sql(arg_dict["source_relation"], arg_dict["target_relation"]) %} 
+{% endmacro %}
+


### PR DESCRIPTION
add hive__get_incremental_default_sql() macro that returns the default incremental sql 

Test result:
<pre>
python -m pytest tests/functional/adapter/test_basic.py -k 'TestIncrementalHive'
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 9 items / 8 deselected / 1 selected

tests/functional/adapter/test_basic.py .                                 [100%]

================= 1 passed, 8 deselected in 336.46s (0:05:36) ==================
</pre>