### PR TITLE
restructure incremental implementation to follow default

### DIFF
--- a/dbt/include/hive/macros/materializations/incremental/incremental.sql
+++ b/dbt/include/hive/macros/materializations/incremental/incremental.sql
@@ -16,37 +16,49 @@
 
 {% materialization incremental, adapter='hive' -%}
   
-  {% set hive_version = get_hive_version() | int %}
-  {{ log("HIVE VERSION " ~ hive_version) }}
+  -- relations
+  {%- set existing_relation = load_cached_relation(this) -%}
+  {%- set target_relation = this.incorporate(type='table') -%}
+  {%- set temp_relation = make_temp_relation(target_relation)-%}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation)-%}
+  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
+  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
+
+
+  -- configs
+  {%- set unique_key = config.get('unique_key') -%}
+  {%- set full_refresh_mode = (should_full_refresh()  or existing_relation.is_view) -%}
+  {%- set on_schema_change = incremental_validate_on_schema_change(config.get('on_schema_change'), default='ignore') -%}
 
   {#-- Validate early so we don't run SQL if the file_format + strategy combo is invalid --#}
   {%- set raw_file_format = config.get('file_format', default='parquet') -%}
-  {%- set raw_strategy = config.get('incremental_strategy', default='append') -%}
-  {% if raw_strategy == None %}
-      {% set raw_strategy = 'append' %}
+  {%- set incremental_strategy = config.get('incremental_strategy', default='append') -%}
+  {% if incremental_strategy == None %}
+      {% set incremental_strategy = 'append' %}
   {% endif %}
 
+  {% do target_relation.log_relation(incremental_strategy) %}
+
+  -- fetch version to check if the strategy is supported
+  {% set hive_version = get_hive_version() | int %}
+  {{ log("HIVE VERSION " ~ hive_version) }}
+
   {#-- support merge in only Hive 3 --#}
-  {% if (hive_version < 3 and raw_strategy == 'merge') %}
+  {% if (hive_version < 3 and incremental_strategy == 'merge') %}
     {% do exceptions.raise_compiler_error("incremental_strategy='merge' is only supported in Hive 3") %}
     {{ return(None) }}
   {% endif %}
-  
-  {%- set file_format = dbt_hive_validate_get_file_format(raw_file_format) -%}
-  {%- set strategy = dbt_hive_validate_get_incremental_strategy(raw_strategy, file_format) -%}
-  
-  {%- set unique_key = config.get('unique_key', none) -%}
-  {%- set partition_by = config.get('partition_by', none) -%}
 
-  -- grab current tables grants config for comparision later on
+  -- the temp_ and backup_ relations should not already exist in the database; get_relation
+  -- will return None in that case. Otherwise, we get a relation that we can drop
+  -- later, before we try to use this name for the current operation. This has to happen before
+  -- BEGIN, in a separate transaction
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation)-%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+   -- grab current tables grants config for comparision later on
   {% set grant_config = config.get('grants') %}
-
-  {%- set full_refresh_mode = (flags.FULL_REFRESH == True) -%}
-
-  {% set target_relation = this.incorporate(type='table') %}
-  {% do target_relation.log_relation(raw_strategy) %}
-  {% set existing_relation = load_relation(this) %}
-  {% set tmp_relation = make_temp_relation(this) %}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
 
   {% if strategy == 'insert_overwrite' and partition_by %}
     {% call statement() %}
@@ -56,34 +68,65 @@
     {% endcall %}
   {% endif %}
 
-  {{ run_hooks(pre_hooks) }}
+  {{ run_hooks(pre_hooks, inside_transaction=False) }}
 
-  {% set drop_temp_relation = False %}
+  -- `BEGIN` happens here:
+  {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% set to_drop = [] %}
 
   {% if existing_relation is none %}
-    {% set build_sql = create_table_as(False, target_relation, sql) %}
-  {% elif existing_relation.is_view or full_refresh_mode %}
-    {% do adapter.drop_relation(existing_relation) %}
-    {% set build_sql = create_table_as(False, target_relation, sql) %}
+      {% set build_sql = get_create_table_as_sql(False, target_relation, sql) %}
+  {% elif full_refresh_mode %}
+      {% set build_sql = get_create_table_as_sql(False, intermediate_relation, sql) %}
+      {% set need_swap = true %}
   {% else %}
-    {{ drop_relation(tmp_relation) }}  {# call the drop_relation macro directy instead of the dbt-core method to avoid type check, as type is null for tmp_relation #}
-    {% do run_query(create_table_as(False, tmp_relation, sql)) %}
-    {% set drop_temp_relation = True %}
-    {% set build_sql = dbt_hive_get_incremental_sql(strategy, tmp_relation, target_relation, unique_key) %}
+    {{ drop_relation(temp_relation) }} 
+    {% do run_query(get_create_table_as_sql(False, temp_relation, sql)) %}
+    {% do to_drop.append(temp_relation) %}
+    {% do adapter.expand_target_column_types(
+             from_relation=temp_relation,
+             to_relation=target_relation) %}
+    {#-- Process schema changes. Returns dict of changes if successful. Use source columns for upserting/merging --#}
+    {% set dest_columns = process_schema_changes(on_schema_change, temp_relation, existing_relation) %}
+    {% if not dest_columns %}
+      {% set dest_columns = adapter.get_columns_in_relation(existing_relation) %}
+    {% endif %}
+
+    {#-- Get the incremental_strategy, the macro to use for the strategy, and build the sql --#}
+    {% set build_sql = dbt_hive_get_incremental_sql(incremental_strategy, temp_relation, target_relation, unique_key) %}}
+
   {% endif %}
 
-  {%- call statement('main') -%}
-    {{ build_sql }}
-  {%- endcall -%}
+  {% call statement("main") %}
+      {{ build_sql }}
+  {% endcall %}
 
-  {{ run_hooks(post_hooks) }}
+  {% if need_swap %}
+      {% do adapter.rename_relation(target_relation, backup_relation) %}
+      {% do adapter.rename_relation(intermediate_relation, target_relation) %}
+      {% do to_drop.append(backup_relation) %}
+  {% endif %}
 
   {% set should_revoke = should_revoke(existing_relation, full_refresh_mode) %}
-  {% do apply_grants(target_relation, grant_config, should_revoke) %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
-  {% if drop_temp_relation %}
-    {{ drop_relation(tmp_relation) }}  {# call the drop_relation macro directy instead of the dbt-core method to avoid type check, as type is null for tmp_relation #}
+  {% do persist_docs(target_relation, model) %}
+
+  {% if existing_relation is none or existing_relation.is_view or should_full_refresh() %}
+    {% do create_indexes(target_relation) %}
   {% endif %}
+
+  {{ run_hooks(post_hooks, inside_transaction=True) }}
+
+  -- `COMMIT` happens here
+  {% do adapter.commit() %}
+
+  {% for rel in to_drop %}
+      {% do adapter.drop_relation(rel) %}
+  {% endfor %}
+
+  {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}
 


### PR DESCRIPTION
## Describe your changes
restructure incremental implementation to follow default dbt-core implementation

## Testing procedure/screenshots(if appropriate):
Test 1 (functional test)
<pre>
(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt-hive % python -m pytest tests/functional/adapter/test_basic.py -k 'TestIncrementalHive' | tee test-incremental3.log
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/dbt-hive
collected 9 items / 8 deselected / 1 selected

tests/functional/adapter/test_basic.py .                                 [100%]

================= 1 passed, 8 deselected in 387.35s (0:06:27) ==================
</pre>

Test 2 (sample and dbt-hive-example)
<pre>
(dev-dbt-hive) ganesh.venkateshwara@ganesh dbtdemo % dbt run -t cloudera-cia-hive_ldap --full-refresh --select models/example/my_incremental_model.sql 
06:00:44  Running with dbt=1.3.1
06:00:44  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 326 macros, 0 operations, 2 seed files, 0 sources, 0 exposures, 0 metrics
06:00:44  
06:01:15  Concurrency: 1 threads (target='cloudera-cia-hive_ldap')
06:01:15  
06:01:15  1 of 1 START sql incremental model dbtdemo.my_incremental_model ................ [RUN]
06:02:26  1 of 1 OK created sql incremental model dbtdemo.my_incremental_model ........... [OK in 71.26s]
06:02:29  
06:02:29  Finished running 1 incremental model in 0 hours 1 minutes and 44.90 seconds (104.90s).
06:02:29  
06:02:29  Completed successfully
06:02:29  
06:02:29  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1


(dev-dbt-hive) ganesh.venkateshwara@ganesh dbtdemo % dbt run -t cloudera-cia-hive_ldap --select models/example/my_incremental_model.sql 
06:03:25  Running with dbt=1.3.1
06:03:25  Found 3 models, 4 tests, 0 snapshots, 0 analyses, 326 macros, 0 operations, 2 seed files, 0 sources, 0 exposures, 0 metrics
06:03:25  
06:03:57  Concurrency: 1 threads (target='cloudera-cia-hive_ldap')
06:03:57  
06:03:57  1 of 1 START sql incremental model dbtdemo.my_incremental_model ................ [RUN]
06:05:28  1 of 1 OK created sql incremental model dbtdemo.my_incremental_model ........... [OK in 90.91s]
06:05:30  
06:05:30  Finished running 1 incremental model in 0 hours 2 minutes and 4.73 seconds (124.73s).
06:05:30  
06:05:30  Completed successfully
06:05:30  
06:05:30  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1


(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt_hive_demo % dbt run -t cloudera-cia-dev_hive --full-refresh 
06:24:09  Running with dbt=1.3.1
06:24:09  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 327 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
06:24:09  
06:25:57  Concurrency: 1 threads (target='cloudera-cia-dev_hive')
06:25:57  
06:25:57  1 of 2 START sql view model dbt_hive_demo_1_staging_covid.stg_covid__cases ..... [RUN]
06:26:05  1 of 2 OK created sql view model dbt_hive_demo_1_staging_covid.stg_covid__cases  [OK in 8.13s]
06:26:05  2 of 2 START sql incremental model dbt_hive_demo_1_mart_covid.covid_cases ...... [RUN]
06:26:35  2 of 2 OK created sql incremental model dbt_hive_demo_1_mart_covid.covid_cases . [OK in 30.61s]
06:26:38  
06:26:38  Finished running 1 view model, 1 incremental model in 0 hours 2 minutes and 28.23 seconds (148.23s).
06:26:38  
06:26:38  Completed successfully
06:26:38  
06:26:38  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2

(dev-dbt-hive) ganesh.venkateshwara@ganesh dbt_hive_demo % dbt run -t cloudera-cia-dev_hive               
06:27:01  Running with dbt=1.3.1
06:27:01  Found 2 models, 13 tests, 0 snapshots, 0 analyses, 327 macros, 0 operations, 4 seed files, 2 sources, 0 exposures, 0 metrics
06:27:01  
06:28:46  Concurrency: 1 threads (target='cloudera-cia-dev_hive')
06:28:46  
06:28:46  1 of 2 START sql view model dbt_hive_demo_1_staging_covid.stg_covid__cases ..... [RUN]
06:28:54  1 of 2 OK created sql view model dbt_hive_demo_1_staging_covid.stg_covid__cases  [OK in 8.26s]
06:28:54  2 of 2 START sql incremental model dbt_hive_demo_1_mart_covid.covid_cases ...... [RUN]
06:30:27  2 of 2 OK created sql incremental model dbt_hive_demo_1_mart_covid.covid_cases . [OK in 92.08s]
06:30:29  
06:30:29  Finished running 1 view model, 1 incremental model in 0 hours 3 minutes and 27.31 seconds (207.31s).
06:30:29  
06:30:29  Completed successfully
06:30:29  
06:30:29  Done. PASS=2 WARN=0 ERROR=0 SKIP=0 TOTAL=2
</pre>