### PR TITLE
fix issues with nested json for cloudera_tracking payload

### DIFF
--- a/dbt/adapters/hive/cloudera_tracking.py
+++ b/dbt/adapters/hive/cloudera_tracking.py
@@ -72,8 +72,8 @@ def populate_dbt_deployment_env_info():
     """
     populate dbt deployment environment variables if available to be passed on for tracking
     """
-    default_value = ""  # if environment variables doesn't exist add empty string as default
-    dbt_deployment_env_info["dbt_deployment_env"] = os.environ.get('DBT_DEPLOYMENT_ENV', default_value)
+    default_value = "{}"  # if environment variables doesn't exist add empty json as default
+    dbt_deployment_env_info["dbt_deployment_env"] = json.loads(os.environ.get('DBT_DEPLOYMENT_ENV', default_value))
 
 def populate_unique_ids(cred: Credentials):
     host = str(cred.host).encode()
@@ -218,12 +218,13 @@ def track_usage(tracking_payload):
             "x-datacoral-passthrough": "true",
         }
 
+        logger.debug(f"Sending Event {data}")
+
         data = json.dumps([data])
 
         res = None
 
         try:
-            logger.debug(f"Sending Event {data}")
             res = requests.post(
                 SNOWPLOW_ENDPOINT,
                 data=data,

--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -414,7 +414,7 @@ class HiveAdapter(SQLAdapter):
                 values = tuple(json_funcs[i](d) for i, d in enumerate(row))
                 permissions_object.append(OrderedDict(zip(row.keys(), values)))
 
-            permissions_json = json.dumps(permissions_object)
+            permissions_json = permissions_object
 
             payload = {
                 "event_type": "dbt_hive_debug_and_fetch_permissions",
@@ -438,7 +438,7 @@ class HiveAdapter(SQLAdapter):
                 values = tuple(json_funcs[i](d) for i, d in enumerate(row))
                 version_object.append(OrderedDict(zip(row.keys(), values)))
 
-            version_json = json.dumps(version_object)
+            version_json = version_object
 
             payload = {
                 "event_type": "dbt_hive_warehouse",


### PR DESCRIPTION
### Describe your changes
fixes issue with nested json for:
warehouse_version
dbt_deployment_env
permissions

### Testing procedure/screenshots(if appropriate):
Perform a dbt debug and check the logs for Tracking data. Set a DBT_DEPLOYMENT_ENV and check the logs.
Sample json payload from the logs attached:

<pre>
[0m13:57:17.202295 [debug] [Thread-9  ]: Tracker adapter: Sending Event {'data': '{"event_type": "dbt_hive_warehouse", "warehouse_version": [{"_c0": "3.1.3000.7.2.15.4-6 r5675879824372d3800b4d655226bc5b45b6e8c2e"}], "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "c424bacb-ef57-4ad4-a41c-7be5e06410e4", "unique_host_hash": "753b4c858f38bb52b2db7b3c8e7569e6", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "8bb2971dfd75fa5e9130c04398a0729f", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-12.6-arm64-arm-64bit", "dbt_version": "1.3.1", "dbt_adapter": "hive-1.3.0", "dbt_deployment_env": {"env": "yarn", "version": "1.2.0"}, "project_name": "dbt_hive_demo", "target_name": "cloudera-cia-dev_hive", "no_of_threads": 1}'}
</pre>