### PR TITLE
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

### DIFF
--- a/dbt/adapters/hive/cloudera_tracking.py
+++ b/dbt/adapters/hive/cloudera_tracking.py
@@ -66,7 +66,8 @@ def populate_platform_info(cred: Credentials, ver):
         "dbt_version"
     ] = dbt.version.get_installed_version().to_version_string(skip_matcher=True)
     # dbt adapter info e.g. impala-1.2.0
-    platform_info["dbt_adapter"] = f"{cred.type}-{ver.version}"
+    platform_info["dbt_adapter_type"] = f"{cred.type}"
+    platform_info["dbt_adapter_version"] = f"{ver.version}"
 
 def populate_dbt_deployment_env_info():
     """


### PR DESCRIPTION
split dbt_adapter field in instrumentation to dbt_adapter_type and dbt_adapter_version

Test Result:
{'data': '{"event_type": "dbt_hive_close", "connection_state": "closed", "elapsed_time": "0.96", "auth": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "684e574f-fe52-4662-9524-090f87575bfb", "unique_host_hash": "753b4c858f38bb52b2db7b3c8e7569e6", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "cf2160b816331e0f0e7e6d8dd1e523f8", "python_version": "3.10.7", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", **"dbt_adapter_type": "hive", "dbt_adapter_version": "1.3.0"**, "dbt_deployment_env": {}, "project_name": "dbt_hive_demo", "target_name": "cloudera_cia_dev_hive", "no_of_threads": 1}'}