### PR TITLE
merge node_id and model_name into one key: model_name

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -336,7 +336,10 @@ class HiveConnectionManager(SQLConnectionManager):
             }
 
             for key, value in additional_info.items():
-                payload[key] = value
+                if key == "node_id":
+                    payload["model_name"] = value
+                else:
+                    payload[key] = value
 
             tracker.track_usage(payload)
 


### PR DESCRIPTION
Merge node_id and model_name into one key: model_name

Sample event payload:

<pre>
[0m10:43:31.398126 [debug] [Thread-33 ]: Tracker adapter: Sending Event {'data': '{"event_type": "dbt_hive_model_access", "model_name": "dbtdemo.my_first_dbt_model", "model_type": "table", "incremental_strategy": "", "auth": "N/A", "connection_state": "N/A", "elapsed_time": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "1acff133-c7d3-44a2-a8d1-d47868ca3b09", "unique_host_hash": "753b4c858f38bb52b2db7b3c8e7569e6", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "e6582a6a226efe74bc9c41af822aa051", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", "dbt_adapter_type": "hive", "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbtdemo", "target_name": "cloudera-cia-hive_ldap", "no_of_threads": 1}'}
</pre>