### PR TITLE
refactor cloudera_tracking: event type as enums, optional userkey, warehouse version fetch 

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -168,6 +168,8 @@ class HiveConnectionWrapper(object):
 class HiveConnectionManager(SQLConnectionManager):
     TYPE = "hive"
 
+    hive_version = None
+
     def __init__(self, profile: AdapterRequiredConfig):
         super().__init__(profile)
         # generate profile related object for instrumentation.
@@ -225,6 +227,8 @@ class HiveConnectionManager(SQLConnectionManager):
             connection.state = ConnectionState.OPEN
             connection.handle = HiveConnectionWrapper(hive_conn)
             connection.handle.cursor()
+
+            HiveConnectionManager.fetch_hive_version(connection.handle)
         except Exception as exc:
             logger.debug("Connection error: {}".format(exc))
             connection_ex = exc
@@ -234,7 +238,7 @@ class HiveConnectionManager(SQLConnectionManager):
 
         # track usage
         payload = {
-            "event_type": "dbt_hive_open",
+            "event_type": tracker.TrackingEventType.OPEN,
             "auth": auth_type,
             "connection_state": connection.state,
             "elapsed_time": "{:.2f}".format(
@@ -272,6 +276,31 @@ class HiveConnectionManager(SQLConnectionManager):
         connection.handle.cancel()
 
     @classmethod
+    def fetch_hive_version(cls, connection):
+
+        if HiveConnectionManager.hive_version: 
+            return HiveConnectionManager.hive_version
+
+        try:
+            sql = "select version()"
+            cursor = connection.cursor()
+            cursor.execute(sql)
+
+            res = cursor.fetchall()
+
+            HiveConnectionManager.hive_version = res[0][0].split(".")[0].strip()
+
+            tracker.populate_warehouse_info({ "version": HiveConnectionManager.hive_version, "build": res[0][0] })
+        except Exception as ex:
+            # we couldn't get the hive warehouse version
+            logger.debug(f"Cannot get hive version. Error: {ex}")
+            HiveConnectionManager.impala_version = "NA"
+
+            tracker.populate_warehouse_info({ "version": HiveConnectionManager.hive_version, "build": "NA" })
+
+        logger.debug(f"HIVE VERSION {'HiveConnectionManager.hive_version'}")
+
+    @classmethod
     def close(cls, connection):
         try:
             # if the connection is in closed or init, there's nothing to do
@@ -283,7 +312,7 @@ class HiveConnectionManager(SQLConnectionManager):
             connection_close_end_time = time.time()
 
             payload = {
-                "event_type": "dbt_hive_close",
+                "event_type": tracker.TrackingEventType.CLOSE,
                 "connection_state": ConnectionState.CLOSED,
                 "elapsed_time": "{:.2f}".format(
                     connection_close_end_time - connection_close_start_time
@@ -330,7 +359,7 @@ class HiveConnectionManager(SQLConnectionManager):
 
             # track usage
             payload = {
-                "event_type": "dbt_hive_start_query",
+                "event_type": tracker.TrackingEventType.START_QUERY,
                 "sql": log_sql,
                 "profile_name": self.profile.profile_name
             }
@@ -365,7 +394,7 @@ class HiveConnectionManager(SQLConnectionManager):
             elapsed_time = time.time() - pre
 
             payload = {
-                "event_type": "dbt_hive_end_query",
+                "event_type": tracker.TrackingEventType.END_QUERY,
                 "sql": log_sql,
                 "elapsed_time": "{:.2f}".format(elapsed_time),
                 "status": query_status,

--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -417,7 +417,7 @@ class HiveAdapter(SQLAdapter):
             permissions_json = permissions_object
 
             payload = {
-                "event_type": "dbt_hive_debug_and_fetch_permissions",
+                "event_type": tracker.TrackingEventType.DEBUG,
                 "permissions": permissions_json,
             }
             tracker.track_usage(payload)
@@ -426,29 +426,6 @@ class HiveAdapter(SQLAdapter):
                 f"Failed to fetch permissions for user: {username}. Exception: {ex}"
             )
             self.connections.get_thread_connection().handle.close()
-
-        # query warehouse version
-        try:
-            sql_query = "select version()"
-            _, table = self.execute(sql_query, True, True)
-            version_object = []
-            json_funcs = [c.jsonify for c in table.column_types]
-
-            for row in table.rows:
-                values = tuple(json_funcs[i](d) for i, d in enumerate(row))
-                version_object.append(OrderedDict(zip(row.keys(), values)))
-
-            version_json = version_object
-
-            payload = {
-                "event_type": "dbt_hive_warehouse",
-                "warehouse_version": version_json,
-            }
-            tracker.track_usage(payload)
-        except Exception as ex:
-            logger.error(
-                f"Failed to fetch warehouse version. Exception: {ex}"
-            )
 
         self.connections.get_thread_connection().handle.close()
 

--- a/dbt/adapters/hive/relation.py
+++ b/dbt/adapters/hive/relation.py
@@ -53,7 +53,7 @@ class HiveRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_hive_model_access",
+                    "event_type": tracker.TrackingEventType.MODEL_ACCESS,
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": "",
@@ -72,7 +72,7 @@ class HiveRelation(BaseRelation):
         if self.type:
             tracker.track_usage(
                 {
-                    "event_type": "dbt_hive_new_incremental",
+                    "event_type": tracker.TrackingEventType.INCREMENTAL,
                     "model_name": self.render(),
                     "model_type": self.type,
                     "incremental_strategy": incremental_strategy,


### PR DESCRIPTION
## Describe your changes
* modify populate_unique_ids to provide optional userkey
* refactor warehouse key, add event type enums
* use the refactored tracking lib: event type, warehouse version 

## Testing:
Using dbt debug, a sample tacking payload in dbt.logs:
<pre>
[0m11:31:56.387989 [debug] [Thread-7  ]: Tracker adapter: Sending Event {'data': '{"event_type": "close", "connection_state": "closed", "elapsed_time": "0.00", "auth": "N/A", "incremental_strategy": "N/A", "model_name": "N/A", "model_type": "N/A", "permissions": "N/A", "profile_name": "N/A", "sql_type": "N/A", "id": "aa9b2613-dbaf-4bae-ac43-9dcca3d68395", "unique_host_hash": "753b4c858f38bb52b2db7b3c8e7569e6", "unique_user_hash": "e8a5d78ea632435d797d3d58df650872", "unique_session_hash": "c4105f2ecbb7065de794797bb2183da9", "python_version": "3.9.12", "system": "Darwin", "machine": "arm64", "platform": "macOS-13.0.1-arm64-arm-64bit", "dbt_version": "1.3.1", "dbt_adapter_type": "hive", "dbt_adapter_version": "1.3.0", "dbt_deployment_env": {}, "project_name": "dbtdemo", "target_name": "cloudera-cia-hive_ldap", "no_of_threads": 1, "warehouse_version": {"version": "3", "build": "3.1.3000.7.2.15.4-6 r5675879824372d3800b4d655226bc5b45b6e8c2e"}}'}
</pre>