### PR TITLE
fix(): avoid closing cursor session across multiple sql statements

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -107,7 +107,8 @@ class HiveConnectionWrapper(object):
         self._cursor = None
 
     def cursor(self):
-        self._cursor = self.handle.cursor()
+        if not self._cursor:
+            self._cursor = self.handle.cursor()
         return self
 
     def cancel(self):


### PR DESCRIPTION
## Describe your changes
Assign self.handle.cursor() to self._cursor everytime will cause self._cursor's __del__() function to be called. And self._cursor.__del__() will call self.session.close(), which will invalid set command defined in pre-hook.

related to #89