### PR TITLE
DBT-714: Fixing the TestBoolOr test, remove the usage of keyword key from the query

### DIFF
--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -190,38 +190,6 @@ class TestAnyValue(BaseAnyValue):
         }
 
 
-models__test_bool_or_sql = """
-with util_data as (
-
-    select * from {{ ref('data_bool_or') }}
-
-),
-
-data_output as (
-
-    select * from {{ ref('data_bool_or_expected') }}
-
-),
-
-calculate as (
-
-    select
-        key,
-        {{ bool_or('val1 = val2') }} as value
-    from util_data
-    group by key
-
-)
-
-select
-    calculate.value as actual,
-    data_output.value as expected
-from calculate
-left join data_output
-on calculate.key = data_output.key
-"""
-
-
 class TestBoolOr(BaseBoolOr):
     @pytest.fixture(scope="class")
     def seeds(self):


### PR DESCRIPTION
## Describe your changes
test_utils.py::TestBoolOr were broken because the query is using the reserved word **key**. 
Base test uses key_column, hence removed the overridden query
 
## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-714

## Testing procedure/screenshots(if appropriate):
Before https://gist.github.com/niteshy/1f415a2dc0736e402e01e9bb4631669c
After https://gist.github.com/niteshy/b34a63919262bbbd14b33098dfa0028d

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
