### PR TITLE
DBT-702: Update basic test to skip testing views, as show commands doesn't work for view

### DIFF
--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -11,10 +11,84 @@ from dbt.tests.adapter.basic.test_incremental import (
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.adapter.utils.base_utils import BaseUtils
+from dbt.tests.util import (
+    run_dbt,
+    check_result_nodes_by_name,
+    relation_from_name,
+    check_relation_types,
+    check_relations_equal,
+)
+from dbt.tests.adapter.basic.files import (
+    base_table_sql,
+    base_materialized_var_sql,
+    schema_base_yml,
+)
 
 
 class TestSimpleMaterializationsHive(BaseSimpleMaterializations):
-    pass
+    """Modified Simple Materialization Hive test.
+    This test has been overridden, because of hive bug
+    https://jira.cloudera.com/browse/CDPD-20768 i.e. show tables statements are not
+    working as expected in hive.
+    Hence, dbt-hive adapter cannot check if the given entity is table or view and
+    default assume them tables.
+    Once, the original issue is fixed, please remove the overriden behavior.
+    """
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "table_model.sql": base_table_sql,
+            "swappable.sql": base_materialized_var_sql,
+            "schema.yml": schema_base_yml,
+        }
+
+    def test_base(self, project):
+        # seed command
+        results = run_dbt(["seed"])
+        # seed result length
+        assert len(results) == 1
+
+        # run command
+        results = run_dbt()
+        # run result length
+        assert len(results) == 2
+
+        # names exist in result nodes
+        check_result_nodes_by_name(results, ["table_model", "swappable"])
+
+        # check relation types
+        expected = {
+            "base": "table",
+            "table_model": "table",
+            "swappable": "table",
+        }
+        check_relation_types(project.adapter, expected)
+
+        # base table rowcount
+        relation = relation_from_name(project.adapter, "base")
+        result = project.run_sql(f"select count(*) as num_rows from {relation}", fetch="one")
+        assert result[0] == 10
+
+        # relations_equal
+        check_relations_equal(project.adapter, ["base", "table_model", "swappable"])
+
+        # check relations in catalog
+        catalog = run_dbt(["docs", "generate"])
+        assert len(catalog.nodes) == 3
+        assert len(catalog.sources) == 1
+
+        # run_dbt changing materialized_var to incremental
+        results = run_dbt(["run", "-m", "swappable", "--vars", "materialized_var: incremental"])
+        assert len(results) == 1
+
+        # check relation types, swappable is table
+        expected = {
+            "base": "table",
+            "table_model": "table",
+            "swappable": "table",
+        }
+        check_relation_types(project.adapter, expected)
 
 
 class TestSingularTestsHive(BaseSingularTests):


### PR DESCRIPTION
## Describe your changes
TestSimpleMaterializationsHive::test_base  were failing because hive show statements are not working in hive ie [CDPD-20768](https://jira.cloudera.com/browse/CDPD-20768). Hence, dbt-hive adapter is not able to identify if the entity is a table or views, because internally it uses a `show` statement to check the table type. 
For the time being, we have overridden the test_base case without the views, so that it doesn't block the test runs.
Ideally once the CDPC-20768 is fixed, we should revert this change.  

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-702

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/94f8a9e6ab4e911b99ef8b1fafb2d386

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
