### PR TITLE
DBT-729: Skipping docs tests because of inconsistent behavior owner attributes

### DIFF
--- a/tests/functional/adapter/test_docs.py
+++ b/tests/functional/adapter/test_docs.py
@@ -24,6 +24,7 @@ from dbt.tests.adapter.basic.expected_catalog import no_stats, base_expected_cat
 from dbt.tests.util import run_dbt, rm_file
 
 
+@pytest.mark.skip(reason="Broken because of owner inconsistency")
 class TestBaseDocsHive(BaseDocsGenerate):
     @pytest.fixture(scope="class")
     def expected_catalog(self, project, profile_user):
@@ -306,6 +307,7 @@ def run_and_generate(project, args=None):
     return start_time
 
 
+@pytest.mark.skip(reason="Broken because of owner inconsistency")
 class TestBaseDocsGenRefsHive(BaseDocsGenReferences):
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
## Describe your changes
Currently, the test_docs.py are failing because of a mismatch in the value of `owner` attributes in the `describe formatted <table>` output. We have inconsistent behavior of describe output, hence skipping docs tests. 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-729

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/71f9b01efeaee254511bb986a891fd79

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
