### PR TITLE
DBT-728: Fixed the handling of partition columns in hive

### DIFF
--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -207,22 +207,54 @@ class HiveAdapter(SQLAdapter):
             pos += 1
         return pos
 
+    @staticmethod
+    def parse_columns_info(raw_rows, start, end):
+        # remove comments columns
+        valid_rows = [
+            (row)
+            for row in raw_rows[start:end]
+            if not row["col_name"].startswith("#") and not row["col_name"] == ""
+        ]
+
+        # avoid overridding duplicate columns by partition columns
+        unique_rows = []
+        for row in valid_rows:
+            curr_unique_keys = list({row["col_name"]: row for row in unique_rows})
+            if row["col_name"] not in curr_unique_keys:
+                unique_rows.append(row)
+        return unique_rows
+
     def parse_describe_formatted(
         self, relation: Relation, raw_rows: List[agate.Row]
     ) -> List[HiveColumn]:
         # Convert the Row to a dict
         dict_rows = [dict(zip(row._keys, row._values)) for row in raw_rows]
-        # Find the separator between the rows and the metadata provided
-        # by the DESCRIBE TABLE FORMATTED statement
-        pos = self.find_table_information_separator(dict_rows)
+        # Find the separator between columns and partitions information
+        # by the DESCRIBE EXTENDED {{relation}} statement
+        partition_separator_pos = self.find_partition_information_separator(dict_rows)
 
-        # Remove rows that start with a hash, they are comments
-        rows = [
-            row
-            for row in raw_rows[0:pos]
-            if row["col_name"] and not row["col_name"].startswith("#")
-        ]
-        metadata = {col["col_name"]: col["data_type"] for col in raw_rows[pos + 1 :]}
+        # Find the separator between the rows and the metadata provided
+        # by the DESCRIBE EXTENDED {{relation}} statement
+        table_separator_pos = self.find_table_information_separator(dict_rows)
+
+        column_separator_pos = (
+            partition_separator_pos if partition_separator_pos > 0 else table_separator_pos
+        )
+        logger.debug(
+            f"relation={relation}, "
+            f"partition_separator_pos = {partition_separator_pos}, "
+            f"table_separator_pos = {table_separator_pos}, "
+            f"column_separator_pos = {column_separator_pos}"
+        )
+
+        # fetch columns info
+        rows = self.parse_columns_info(raw_rows, 0, table_separator_pos)
+
+        metadata = {
+            col["col_name"].split(":")[0].strip(): col["data_type"].strip()
+            for col in raw_rows[table_separator_pos + 1 :]
+            if col["col_name"] and not col["col_name"].startswith("#") and col["data_type"]
+        }
 
         # raw_table_stats = metadata.get(KEY_TABLE_STATISTICS)
         # table_stats = HiveColumn.convert_table_stats(raw_table_stats)
@@ -232,6 +264,10 @@ class HiveAdapter(SQLAdapter):
         for k in metadata:
             new_metadata[k.strip()] = metadata[k].strip() if metadata[k] else ""
         metadata = new_metadata
+
+        # logger.debug(f'metadata = {pformat(metadata)}')
+        # logger.debug(f'rows = {pformat(rows)}')
+        # logger.debug(f'dict_rows = {pformat(dict_rows)}')
 
         return [
             HiveColumn(
@@ -247,6 +283,20 @@ class HiveAdapter(SQLAdapter):
             )
             for idx, column in enumerate(rows)
         ]
+
+    @staticmethod
+    def find_partition_information_separator(rows: List[dict]) -> int:
+        pos = 0
+        ps_keys = [
+            "# Partition Information",  # non-iceberg
+            "# Partition Transform Information",  # iceberg
+        ]
+        for row in rows:
+            if row["col_name"] and row["col_name"].startswith(tuple(ps_keys)):
+                break
+            pos += 1
+        result = 0 if (pos == len(rows)) else pos
+        return result
 
     @staticmethod
     def find_table_information_separator(rows: List[dict]) -> int:

--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -265,10 +265,6 @@ class HiveAdapter(SQLAdapter):
             new_metadata[k.strip()] = metadata[k].strip() if metadata[k] else ""
         metadata = new_metadata
 
-        # logger.debug(f'metadata = {pformat(metadata)}')
-        # logger.debug(f'rows = {pformat(rows)}')
-        # logger.debug(f'dict_rows = {pformat(dict_rows)}')
-
         return [
             HiveColumn(
                 table_database=None,

--- a/tests/functional/adapter/test_table_type.py
+++ b/tests/functional/adapter/test_table_type.py
@@ -270,7 +270,6 @@ class TestIncrementalIcebergHive(BaseIncremental):
         assert len(catalog.sources) == 1
 
 
-@pytest.mark.skip(reason="Not working because increment insert queries are not working")
 class TestIncrementalPartitionIcebergHive(TestIncrementalIcebergHive):
     @pytest.fixture(scope="class")
     def models(self):
@@ -280,7 +279,6 @@ class TestIncrementalPartitionIcebergHive(TestIncrementalIcebergHive):
         }
 
 
-@pytest.mark.skip(reason="Not working because increment insert queries are not working")
 class TestIncrementalMultiplePartitionIcebergHive(TestIncrementalIcebergHive):
     @pytest.fixture(scope="class")
     def models(self):
@@ -290,7 +288,7 @@ class TestIncrementalMultiplePartitionIcebergHive(TestIncrementalIcebergHive):
         }
 
 
-@pytest.mark.skip(reason="Not working because increment insert queries are not working")
+@pytest.mark.skip(reason="Not working because insert queries is not working as expected")
 class TestInsertOverwriteIcebergHive(TestIncrementalIcebergHive):
     @pytest.fixture(scope="class")
     def models(self):

--- a/tests/functional/adapter/test_table_type.py
+++ b/tests/functional/adapter/test_table_type.py
@@ -288,7 +288,7 @@ class TestIncrementalMultiplePartitionIcebergHive(TestIncrementalIcebergHive):
         }
 
 
-@pytest.mark.skip(reason="Not working because insert queries is not working as expected")
+@pytest.mark.skip(reason="Not working because insert queries are not working as expected")
 class TestInsertOverwriteIcebergHive(TestIncrementalIcebergHive):
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
## Describe your changes
Insert query required the list of columns in the tables. We use the `describe formatted` command to find the table metadata like columns, partition columns, etc. Currently, the `describe formatted` has compatibility issues like following

1. `describe formatted <table>` for normal tables is not returning the partition columns in the columns list vs iceberg tables output has partition columns in the main list, and also in the partition sections too. 
2. `describe formatted <table>` has different partition section headers eg `# Partition Information` used for non-iceberg
Vs `"# Partition Transform Information` used for iceberg table. 

To handle these issues, we are parsing and aggregating the column list from main section and partition sections. Using it as collective columns list. 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-728

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/211fff5460c38dfbe7564745ce290e63

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
