### PR TITLE
DBT-718: Handling the kerberos module installation for different platforms

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -61,6 +61,7 @@ class HiveCredentials(Credentials):
     password: Optional[str] = None
     auth_type: Optional[str] = None
     use_ssl: Optional[bool] = True
+    ca_cert: Optional[str] = None
     use_http_transport: Optional[bool] = True
     http_path: Optional[str] = None
     kerberos_service_name: Optional[str] = None
@@ -223,6 +224,7 @@ class HiveConnectionManager(SQLConnectionManager):
                     kerberos_service_name=credentials.kerberos_service_name,
                     use_http_transport=credentials.use_http_transport,
                     use_ssl=credentials.use_ssl,
+                    ca_cert=credentials.ca_cert,
                 )
             else:
                 raise dbt.exceptions.DbtProfileError(
@@ -236,7 +238,7 @@ class HiveConnectionManager(SQLConnectionManager):
 
             HiveConnectionManager.fetch_hive_version(connection.handle)
         except Exception as exc:
-            logger.debug(f"Connection error: {exc}")
+            logger.error(f"Connection error: {exc}")
             connection_ex = exc
             connection.state = ConnectionState.FAIL
             connection.handle = None

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ setup(
         "impyla==0.18",
         "sqlparams>=3.0.0",
         "python-decouple>=3.6",
-        "kerberos>=1.3.0",
+        "kerberos>=1.3.0; platform_system == 'Darwin' or platform_system == 'Linux' ",
+        "winkerberos>=0.9.1; platform_system == 'Windows' ",
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from distutils.util import strtobool
 import pytest
 import os
 
@@ -29,6 +30,8 @@ def dbt_profile_target(request):
     profile_type = request.config.getoption("--profile")
     if profile_type == "cdh_endpoint":
         target = cdh_target()
+    elif profile_type == "cdh_kerberos_endpoint":
+        target = cdh_kerberos_target()
     elif profile_type == "dwx_endpoint":
         target = dwx_target()
     elif profile_type == "local_endpoint":
@@ -48,6 +51,21 @@ def cdh_target():
         "user": os.getenv("DBT_HIVE_USER"),
         "password": os.getenv("DBT_HIVE_PASSWORD"),
         "use_http_transport": False,
+    }
+
+
+def cdh_kerberos_target():
+    return {
+        "type": "hive",
+        "threads": 4,
+        "auth_type": "kerberos",
+        "host": os.getenv("DBT_HIVE_HOST"),
+        "port": int(os.getenv("DBT_HIVE_PORT")),
+        "schema": os.getenv("DBT_HIVE_SCHEMA") or "dbt_adapter_test",
+        "kerberos_service_name": os.getenv("DBT_HIVE_KERBEROS_SERVICE_NAME") or "hive",
+        "use_http_transport": bool(strtobool(os.getenv("DBT_HIVE_USE_HTTP_TRANSPORT") or "f")),
+        "use_ssl": bool(strtobool(os.getenv("DBT_HIVE_USE_SSL") or "f")),
+        "ca_cert": os.getenv("DBT_CA_CERT") or None,
     }
 
 


### PR DESCRIPTION
## Describe your changes
The Python `Kerberos` module is only available on Unix/Linux platforms, so dbt-hive installation failed on the Windows platform. 
To resolve the issue, we are installing the modules based on the platform. Even though we have installed the Winkerberos module for Windows. At this time, it is difficult to setup the Kerberos setup for windows. Hence, we qualified the windows using non-kerberos (LDAP) endpoint

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-718

## Testing procedure/screenshots(if appropriate):
Kerberos Setup https://gist.github.com/niteshy/435e3efeded42c56663979180a3f8ba9 

Mac Testing 
Using Kerberos endpoint https://gist.github.com/niteshy/14d467a78d2f162c6bea5efab3340acc 
Using non-Kerberos (LDAP) endpoint https://gist.github.com/niteshy/39d2414f232637b513590517ff606f72 

Linux Testing 
Using Kerberos endpoint https://gist.github.com/niteshy/5b84c36ee1f45b26542fc0363966fcb1
> One failure is explained [here](https://gist.github.com/niteshy/5b84c36ee1f45b26542fc0363966fcb1#file-dbt-hive-bugfix_kerberos_win-testing-on-linux-L1519)  

Windows Testing 
Using non-Kerberos (LDAP) endpoint https://gist.github.com/niteshy/d9cd9274edf04350cf8e6493801525db because we are not able to set up Kerberos authentication on Windows 
 


## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
