### PR TITLE
DBT-731: Iceberg: Fixing the incremental overwrite strategy, insert statements

### DIFF
--- a/dbt/include/hive/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/hive/macros/materializations/incremental/strategies.sql
@@ -17,9 +17,12 @@
 {% macro get_insert_overwrite_sql(source_relation, target_relation) %}
 
     {%- set dest_columns = adapter.get_columns_in_relation(target_relation) -%}
+    {%- set table_type = config.get('table_type') -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
     insert overwrite table {{ target_relation }}
-    {{ partition_cols(label="partition") }}
+    {% if table_type != 'iceberg' -%}
+      {{ partition_cols(label="partition") }}
+    {%- endif %}
     select {{dest_cols_csv}} from {{ source_relation.include(database=false, schema=true) }}
 
 {% endmacro %}

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -168,6 +168,20 @@ select
     {% endif %}
 """
 
+insertoverwrite_sql = """
+{{ config(materialized="incremental", incremental_strategy="insert_overwrite", partition_by="id_partition") }}
+select *, id as id_partition from {{ source('raw', 'seed') }}
+    {% if is_incremental() %}
+        where id > (select max(id) from {{ this }})
+    {% endif %}
+""".strip()
+
+
+class TestInsertOverwriteHive(BaseIncremental):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"incremental.sql": insertoverwrite_sql, "schema.yml": schema_base_yml}
+
 
 class TestBaseIncrementalNotSchemaChange(BaseIncrementalNotSchemaChange):
     @pytest.fixture(scope="class")

--- a/tests/functional/adapter/test_table_type.py
+++ b/tests/functional/adapter/test_table_type.py
@@ -288,7 +288,6 @@ class TestIncrementalMultiplePartitionIcebergHive(TestIncrementalIcebergHive):
         }
 
 
-@pytest.mark.skip(reason="Not working because insert queries are not working as expected")
 class TestInsertOverwriteIcebergHive(TestIncrementalIcebergHive):
     @pytest.fixture(scope="class")
     def models(self):


### PR DESCRIPTION
## Describe your changes
For the incremental overwrite strategy (iceberg), insert statements are failing for tables containing partition columns. 
Previously, insert queries has a partition clause which is not supported for the iceberg table eg.
```
insert overwrite table incremental
partition (id_partition)
select `id`, `name`, `some_date`, `id_partition` from incremental__dbt_tmp;
```
After fix 
```
insert overwrite table incremental_test_model
select `id`, `name`, `some_date`, `id_partition1` from incremental_test_model__dbt_tmp;
```

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-731

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niteshy/6f73c1dd590250d3c8050543e978bbda

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
