### PR TITLE
DBT-736: Add support for iceberg v2 spec 

### DIFF
--- a/dbt/include/hive/macros/adapters.sql
+++ b/dbt/include/hive/macros/adapters.sql
@@ -119,7 +119,7 @@
 {%- endmacro -%}
 
 {% macro hive__create_table_as(temporary, relation, sql) -%}
-  {%- set _properties = config.get('properties') -%}
+  {%- set _properties = config.get('tbl_properties') -%}
   {%- set is_external = config.get('external') -%}
   {%- set table_type = config.get('table_type') -%}
 

--- a/tests/functional/adapter/iceberg_files.py
+++ b/tests/functional/adapter/iceberg_files.py
@@ -1,0 +1,79 @@
+from dbt.tests.adapter.basic.files import model_base, model_incremental
+
+iceberg_base_table_sql = (
+    """
+{{
+  config(
+    materialized="table",
+    table_type="iceberg"
+  )
+}}""".strip()
+    + model_base
+)
+
+iceberg_base_materialized_var_sql = (
+    """
+{{
+  config(
+    materialized=var("materialized_var", "table"),
+    table_type="iceberg"
+  )
+}}""".strip()
+    + model_base
+)
+
+incremental_iceberg_sql = (
+    """
+ {{
+    config(
+        materialized="incremental",
+        table_type="iceberg"
+    )
+}}
+""".strip()
+    + model_incremental
+)
+
+
+incremental_partition_iceberg_sql = """
+ {{
+    config(
+        materialized="incremental",
+        partition_by="id",
+        table_type="iceberg"
+    )
+}}
+select *, id as id_partition1 from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+    where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()
+
+incremental_multiple_partition_iceberg_sql = """
+ {{
+    config(
+        materialized="incremental",
+        partition_by=["id_partition1", "id_partition2"],
+        table_type="iceberg"
+    )
+}}
+select *, id as id_partition1, id as id_partition2 from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+    where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()
+
+insertoverwrite_iceberg_sql = """
+ {{
+    config(
+        materialized="incremental",
+        incremental_strategy="insert_overwrite",
+        partition_by="id_partition1",
+        table_type="iceberg"
+    )
+}}
+select *, id as id_partition1 from {{ source('raw', 'seed') }}
+{% if is_incremental() %}
+    where id > (select max(id) from {{ this }})
+{% endif %}
+""".strip()

--- a/tests/functional/adapter/test_iceberg_v2.py
+++ b/tests/functional/adapter/test_iceberg_v2.py
@@ -1,0 +1,91 @@
+import pytest
+import re
+
+from tests.functional.adapter.iceberg_files import (
+    iceberg_base_table_sql,
+    incremental_iceberg_sql,
+    incremental_partition_iceberg_sql,
+    incremental_multiple_partition_iceberg_sql,
+    insertoverwrite_iceberg_sql,
+)
+
+from tests.functional.adapter.test_iceberg_v1 import (
+    BaseSimpleMaterializationsForIceberg,
+    BaseIncrementalForIceberg,
+)
+
+from dbt.tests.adapter.basic.files import model_base, base_view_sql, schema_base_yml
+
+iceberg_base_materialized_var_sql = (
+    """
+    {{
+      config(
+        materialized=var("materialized_var", "table"),
+        table_type="iceberg",
+        tbl_properties={"format-version": "2"}
+      )
+    }}""".strip()
+    + model_base
+)
+
+
+def replace_with_iceberg_v2(model):
+    # Add iceberg table_type as a config parameter for existing tests
+    pattern = r"(config\s*\([^)]*\))"
+    result = re.sub(
+        pattern,
+        lambda x: x.group(0).rstrip(")") + ', tbl_properties={"format-version": "2"})',
+        model,
+    )
+    return result
+
+
+class TestSimpleMaterializationsIcebergV2Hive(BaseSimpleMaterializationsForIceberg):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "view_model.sql": base_view_sql,
+            "table_model.sql": replace_with_iceberg_v2(iceberg_base_table_sql),
+            "swappable.sql": iceberg_base_materialized_var_sql,
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestIncrementalIcebergV2Hive(BaseIncrementalForIceberg):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": replace_with_iceberg_v2(incremental_iceberg_sql),
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestIncrementalPartitionIcebergV2Hive(BaseIncrementalForIceberg):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": replace_with_iceberg_v2(
+                incremental_partition_iceberg_sql
+            ),
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestIncrementalMultiplePartitionIcebergV2Hive(BaseIncrementalForIceberg):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": replace_with_iceberg_v2(
+                incremental_multiple_partition_iceberg_sql
+            ),
+            "schema.yml": schema_base_yml,
+        }
+
+
+class TestInsertOverwriteIcebergV2Hive(BaseIncrementalForIceberg):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": replace_with_iceberg_v2(insertoverwrite_iceberg_sql),
+            "schema.yml": schema_base_yml,
+        }

--- a/tests/functional/adapter/test_table_type.py
+++ b/tests/functional/adapter/test_table_type.py
@@ -54,7 +54,10 @@ iceberg_base_table_sql = (
 {{
   config(
     materialized="table",
-    table_type="iceberg"
+    table_type="iceberg",
+    tbl_properties={
+      "format-version": "2"
+    }
   )
 }}""".strip()
     + model_base
@@ -65,7 +68,10 @@ iceberg_base_materialized_var_sql = (
 {{
   config(
     materialized=var("materialized_var", "table"),
-    table_type="iceberg"
+    table_type="iceberg",
+    tbl_properties={
+      "format-version": "2"
+    }
   )
 }}""".strip()
     + model_base
@@ -76,7 +82,10 @@ incremental_iceberg_sql = (
  {{
     config(
         materialized="incremental",
-        table_type="iceberg"
+        table_type="iceberg",
+        tbl_properties={
+          "format-version": "2"
+        }
     )
 }}
 """.strip()
@@ -89,7 +98,10 @@ incremental_partition_iceberg_sql = """
     config(
         materialized="incremental",
         partition_by="id",
-        table_type="iceberg"
+        table_type="iceberg",
+        tbl_properties={
+          "format-version": "2"
+        }
     )
 }}
 select *, id as id_partition1 from {{ source('raw', 'seed') }}
@@ -103,7 +115,10 @@ incremental_multiple_partition_iceberg_sql = """
     config(
         materialized="incremental",
         partition_by=["id_partition1", "id_partition2"],
-        table_type="iceberg"
+        table_type="iceberg",
+        tbl_properties={
+          "format-version": "2"
+        }
     )
 }}
 select *, id as id_partition1, id as id_partition2 from {{ source('raw', 'seed') }}
@@ -118,7 +133,10 @@ insertoverwrite_iceberg_sql = """
         materialized="incremental",
         incremental_strategy="insert_overwrite",
         partition_by="id_partition1",
-        table_type="iceberg"
+        table_type="iceberg",
+        tbl_properties={
+          "format-version": "2"
+        }
     )
 }}
 select *, id as id_partition1 from {{ source('raw', 'seed') }}
@@ -293,5 +311,27 @@ class TestInsertOverwriteIcebergHive(TestIncrementalIcebergHive):
     def models(self):
         return {
             "incremental_test_model.sql": insertoverwrite_iceberg_sql,
+            "schema.yml": schema_base_yml,
+        }
+
+
+incremental_iceberg_sql_v1 = (
+    """
+ {{
+    config(
+        materialized="incremental",
+        table_type="iceberg"
+    )
+}}
+""".strip()
+    + model_incremental
+)
+
+
+class TestIncrementalIcebergV1Hive(TestIncrementalIcebergHive):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "incremental_test_model.sql": incremental_iceberg_sql_v1,
             "schema.yml": schema_base_yml,
         }


### PR DESCRIPTION
## Describe your changes
As part of this change, Added support for format-version which enables users to create iceberg tables with v2 spec.

## Internal Jira ticket number or external issue link:
https://jira.cloudera.com/browse/DBT-736

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/vamshikolanu/be8a77ebcda6216c12f118adcef8c13a

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
