### PR TITLE
DBT-738: Fix insert overwrite logic for iceberg and non-partition tables

### DIFF
--- a/dbt/include/hive/macros/materializations/incremental/strategies.sql
+++ b/dbt/include/hive/macros/materializations/incremental/strategies.sql
@@ -20,9 +20,7 @@
     {%- set table_type = config.get('table_type') -%}
     {%- set dest_cols_csv = dest_columns | map(attribute='quoted') | join(', ') -%}
     insert overwrite table {{ target_relation }}
-    {% if table_type != 'iceberg' -%}
-      {{ partition_cols(label="partition") }}
-    {%- endif %}
+    {{ partition_cols(label="partition") }}
     select {{dest_cols_csv}} from {{ source_relation.include(database=false, schema=true) }}
 
 {% endmacro %}

--- a/tests/functional/adapter/iceberg_files.py
+++ b/tests/functional/adapter/iceberg_files.py
@@ -62,18 +62,3 @@ select *, id as id_partition1, id as id_partition2 from {{ source('raw', 'seed')
     where id > (select max(id) from {{ this }})
 {% endif %}
 """.strip()
-
-insertoverwrite_iceberg_sql = """
- {{
-    config(
-        materialized="incremental",
-        incremental_strategy="insert_overwrite",
-        partition_by="id_partition1",
-        table_type="iceberg"
-    )
-}}
-select *, id as id_partition1 from {{ source('raw', 'seed') }}
-{% if is_incremental() %}
-    where id > (select max(id) from {{ this }})
-{% endif %}
-""".strip()

--- a/tests/functional/adapter/test_iceberg_v1.py
+++ b/tests/functional/adapter/test_iceberg_v1.py
@@ -40,7 +40,6 @@ from tests.functional.adapter.iceberg_files import (
     incremental_iceberg_sql,
     incremental_partition_iceberg_sql,
     incremental_multiple_partition_iceberg_sql,
-    insertoverwrite_iceberg_sql,
 )
 
 
@@ -218,14 +217,5 @@ class TestIncrementalMultiplePartitionIcebergHive(BaseIncrementalForIceberg):
     def models(self):
         return {
             "incremental_test_model.sql": incremental_multiple_partition_iceberg_sql,
-            "schema.yml": schema_base_yml,
-        }
-
-
-class TestInsertOverwriteIcebergHive(BaseIncrementalForIceberg):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "incremental_test_model.sql": insertoverwrite_iceberg_sql,
             "schema.yml": schema_base_yml,
         }

--- a/tests/functional/adapter/test_iceberg_v2.py
+++ b/tests/functional/adapter/test_iceberg_v2.py
@@ -6,7 +6,6 @@ from tests.functional.adapter.iceberg_files import (
     incremental_iceberg_sql,
     incremental_partition_iceberg_sql,
     incremental_multiple_partition_iceberg_sql,
-    insertoverwrite_iceberg_sql,
 )
 
 from tests.functional.adapter.test_iceberg_v1 import (
@@ -78,14 +77,5 @@ class TestIncrementalMultiplePartitionIcebergV2Hive(BaseIncrementalForIceberg):
             "incremental_test_model.sql": replace_with_iceberg_v2(
                 incremental_multiple_partition_iceberg_sql
             ),
-            "schema.yml": schema_base_yml,
-        }
-
-
-class TestInsertOverwriteIcebergV2Hive(BaseIncrementalForIceberg):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "incremental_test_model.sql": replace_with_iceberg_v2(insertoverwrite_iceberg_sql),
             "schema.yml": schema_base_yml,
         }


### PR DESCRIPTION
## Describe your changes
Currently for iceberg and non-partition tables, insert overwrite acts like a full refresh which is incorrect. 

The main idea behind the insert-overwrite strategy is to work with partitions. The insert overwrite strategy should ideally delete the data from selected partitions of the table and insert the newly transformed data into partitions. 

Hence removing the existing logic for iceberg and non-partition tables. In upcoming releases, we can support insert-overwrite for iceberg tables by removing the overlapping partitions and re-inserting the data. 

## Internal Jira ticket number or external issue link:
https://jira.cloudera.com/browse/DBT-738

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/vamshikolanu/d2d6c0772e5dfb54149b472416bd7dde

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
