### PR TITLE
DBT-763: DBT-764: Upgrading the dbt-core to v1.5.10 and resolving issues

### DIFF
--- a/dbt/adapters/hive/__version__.py
+++ b/dbt/adapters/hive/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = "1.4.0"
+version = "1.5.0"

--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -99,6 +99,10 @@ class HiveCredentials(Credentials):
     def type(self):
         return "hive"
 
+    @property
+    def unique_field(self) -> str:
+        return f"{self.host}_{self.schema}_{self.username}"
+
     def _connection_keys(self):
         return "host", "schema", "user"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.4.*
+dbt-tests-adapter==1.5.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-hive"
 # make sure this always matches dbt/adapters/hive/__version__.py
-package_version = "1.4.0"
+package_version = "1.5.0"
 description = """The Hive adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()
@@ -77,6 +77,7 @@ setup(
         "impyla==0.18",
         "sqlparams>=3.0.0",
         "python-decouple>=3.6",
+        "protobuf>=4.0.0,<5",  # we need to freeze the version because the dbt-core backports are not cleanly done
         "kerberos>=1.3.0; platform_system == 'Darwin' or platform_system == 'Linux' ",
         "winkerberos>=0.9.1; platform_system == 'Windows' ",
     ],

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,10 @@ setup(
         "impyla==0.18",
         "sqlparams>=3.0.0",
         "python-decouple>=3.6",
-        "protobuf>=4.0.0,<5",  # we need to freeze the version because the dbt-core backports are not cleanly done
+        # pining the protobuf version to 4.x because the dbt-core backports were messed up.
+        # more details in https://github.com/dbt-labs/dbt-core/issues/9830.
+        # TODO: remove this pin once the above issue and https://github.com/dbt-labs/dbt-core/issues/9724 is resolved.
+        "protobuf>=4.0.0,<5",
         "kerberos>=1.3.0; platform_system == 'Darwin' or platform_system == 'Linux' ",
         "winkerberos>=0.9.1; platform_system == 'Windows' ",
     ],


### PR DESCRIPTION
## Describe your changes

Upgrading dbt-core to 1.5.10 resulted in the following issues: 

1. dbt-core surfaced two weeks ago [#9759](https://github.com/dbt-labs/dbt-core/issues/9759) when protobuf has released 5.26.0 version which is not compatible with dbt-core. Even though they fixed the issue by pining the version but the backports were NOT done correctly resulting in broken adapters. More details here https://github.com/dbt-labs/dbt-core/issues/9830. Causing issues #135
2. HiveCredentials extends the dbt-core Credentials class, which is required to implement the unique_field() method. This has caused the issues  #136

Resolve #135, #136

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-763
https://jira.cloudera.com/browse/DBT-764

## Testing procedure/screenshots(if appropriate):
Verified the version upgrade and successful run of all tests https://gist.github.com/niteshy/c5adf6d0a195a8e3c7472185f4bfb4c2 

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
