### PR TITLE
DBT-770: Removing logging from tracking adapter when disabled

### DIFF
--- a/dbt/adapters/hive/cloudera_tracking.py
+++ b/dbt/adapters/hive/cloudera_tracking.py
@@ -200,13 +200,8 @@ def track_usage(tracking_payload):
 
     global usage_tracking
 
-    logger.debug(
-        f"Usage tracking flag {usage_tracking}. To turn on/off use usage_tracking flag in profiles.yml"
-    )
-
     # if usage_tracking is disabled, quit
     if not usage_tracking:
-        logger.debug(f"Skipping Event {tracking_payload}")
         return
 
     # fix the schema of tracking payload to be common for all events

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ def dwx_target():
         "user": os.getenv("DBT_HIVE_USER"),
         "password": os.getenv("DBT_HIVE_PASSWORD"),
         "http_path": os.getenv("DBT_HIVE_HTTP_PATH") or "cliservice",
+        "usage_tracking": False,
     }
 
 


### PR DESCRIPTION
## Describe your changes
Currently, there are many logs regarding tracking adapter even when disabled. For example:

```
16:40:25  Tracker adapter: Usage tracking flag False. To turn on/off use usage_tracking flag in profiles.yml
16:40:25  Tracker adapter: Skipping Event {'event_type': 'open', 'auth': 'ldap', 'connection_state': <ConnectionState.OPEN: 'open'>, 'elapsed_time': '0.00'}
```

This patch will reduce the noise of these logs when its disabled

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-770

## Testing procedure/screenshots(if appropriate):

Before the change: https://gist.github.com/vamshikolanu/524bf70a4bd5199cc0d3f909790f2ac2
After the change: https://gist.github.com/vamshikolanu/03a8fe2add50b8c22c4a169c38b8b506

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
