### PR TITLE
DBT-773: Updating TestConcat and TestHash to be consistent with version 1.6

### DIFF
--- a/dbt/adapters/hive/__version__.py
+++ b/dbt/adapters/hive/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = "1.5.0"
+version = "1.6.0"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.5.*
+dbt-tests-adapter==1.6.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-hive"
 # make sure this always matches dbt/adapters/hive/__version__.py
-package_version = "1.5.0"
+package_version = "1.6.0"
 description = """The Hive adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()

--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -237,32 +237,8 @@ class TestCastBoolToText(BaseCastBoolToText):
         }
 
 
-models__test_concat_sql = """
-with util_data as (
-
-    select * from {{ ref('data_concat') }}
-
-)
-
-select
-    {{ concat(['input_1', 'input_2']) }} as actual,
-    output as expected
-
-from util_data
-"""
-
-
 class TestConcat(BaseConcat):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"data_concat.csv": seeds__data_concat_csv}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "test_concat.yml": models__test_concat_yml,
-            "test_concat.sql": self.interpolate_macro_namespace(models__test_concat_sql, "concat"),
-        }
+    pass
 
 
 models__test_dateadd_sql = """
@@ -389,32 +365,8 @@ class TestExcept(BaseExcept):
     pass
 
 
-models__test_hash_sql = """
-with util_data as (
-
-    select * from {{ ref('data_hash') }}
-
-)
-
-select
-    {{ hash('input_1') }} as actual,
-    output as expected
-
-from util_data
-"""
-
-
 class TestHash(BaseHash):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"data_hash.csv": seeds__data_hash_csv}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "test_hash.yml": models__test_hash_yml,
-            "test_hash.sql": self.interpolate_macro_namespace(models__test_hash_sql, "hash"),
-        }
+    pass
 
 
 class TestIntersect(BaseIntersect):


### PR DESCRIPTION
## Describe your changes
With version 1.6, these changes (https://github.com/dbt-labs/dbt-core/pull/7776/commits/494753cf019ce2af5a2208d41cee3de3f59db60a) have been made on the dbt-core side for TestHash and TestConcat, and due to the resulting inconsistency in our sql and the updated sql of dbt-core, the tests are throwing error. This PR suggest to update the sql in dbt-hive for the above tests to include the changes introduced in core, but instead of repeating the same code, just bypassing the tests to dbt-core. 
## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-773
## Testing procedure/screenshots(if appropriate):
Individual Tests
TestConcat-(https://gist.github.com/nsharma-25/3840fdb05732f72847fbf1835874bedc)
TestHash- (https://gist.github.com/nsharma-25/f4405f44f2057bf9e23653dd86ed9d2a)
All tests- https://gist.github.com/nsharma-25/d6cb6090f4f6b70a7c974c39377a1b73
## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
