### PR TITLE
DBT-774: Changes in TestRight

### DIFF
--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -600,7 +600,7 @@ with util_data as (
 )
 select
     {{ right('string_text', 'length_expression') }} as actual,
-    coalesce(output, '') as expected
+    nullif(output, '') as expected
 from util_data
 """
 


### PR DESCRIPTION
## Describe your changes
For TestRight, the current sql is mentioned below, however with this sql, in the case when length_epression = 0, we are getting NULL in actual column whereas in expected column of test_right we are getting an empty string, which is currently not throwing any error with version 1.5 because of this bug (https://github.com/dbt-labs/dbt-core/issues/7778) which has been fixed in 1.6, and hence it throws error with that version of dbt-core. 

```
create or replace view test_right
  
  as
    with util_data as (
    select * from data_right
)
select
    

    case when length_expression = 0
        then NULL
    else
        substr(
        string_text,
        (length(string_text)-cast(length_expression as int)+1),
        length(string_text)-1
    )
    end as actual,
    coalesce(output, '') as expected
from util_data
```
This PR suggests to update the sql, so that the empty strings in the expected column of test_right get converted to NULL.


## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-774
## Testing procedure/screenshots(if appropriate):
TestRight in v1.5 - https://gist.github.com/nsharma-25/12a9fb50bd468ba1d6011334874925a2
TestRight in v1.6 - https://gist.github.com/nsharma-25/f28a783d003114de78e4a314ad453ea0
All Tests in v1.5- https://gist.github.com/nsharma-25/a7368721576fb58593d4163218c5ae4e
All Tests in v1.6 -  https://gist.github.com/nsharma-25/7846b543427a12517e6b2674f12feadc
## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I have formatted my added/modified code to follow pep-8 standards
- [ ] I have checked suggestions from python linter to make sure code is of good quality.
