### PR TITLE
DBT-775: Fix split part macro to return empty string instead of null

### DIFF
--- a/dbt/include/hive/macros/utils/split_part.sql
+++ b/dbt/include/hive/macros/utils/split_part.sql
@@ -25,12 +25,13 @@
     {% endset %}
 
     {% set split_part_expr %}
-
-    split(
-        {{ string_text }},
-        {{ delimiter_expr }}
-        )[({{ part_number - 1 }})]
-
+        coalesce(
+            split(
+                {{ string_text }},
+                {{ delimiter_expr }}
+            )[({{ part_number - 1 }})],
+            ''
+        )
     {% endset %}
 
     {{ return(split_part_expr) }}


### PR DESCRIPTION
## Describe your changes
Currently, split_part macros returns NULL when part_number is out of index. DBT expects the return value to be equal to empty string.

Example:
split_part('11.22.33', '.',  4) -> Previously returns NULL. After the change this returns ''.

## Internal Jira ticket number or external issue link:
https://jira.cloudera.com/browse/DBT-775


## Testing procedure/screenshots(if appropriate):
1.5 test: https://gist.github.com/vamshikolanu/06bc9f560178fb8d6ac32336d42af283
1.5 full tests: https://gist.github.com/vamshikolanu/399138cb7b9e88244bd5b5598c1e92fc
1.6 test: https://gist.github.com/vamshikolanu/f9768bad825e04fd297676e1718a3fc3

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
