### PR TITLE
DBT-774: Modifying the macro for TestRight to return empty string('') instead of NULL

### DIFF
--- a/dbt/include/hive/macros/utils/right.sql
+++ b/dbt/include/hive/macros/utils/right.sql
@@ -16,7 +16,7 @@
 {% macro hive__right(string_text, length_expression) %}
 
     case when {{ length_expression }} = 0
-        then NULL
+        then ''
     else
         substr(
         {{ string_text }},

--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -594,28 +594,8 @@ class TestReplace(BaseReplace):
         }
 
 
-models__test_right_sql = """
-with util_data as (
-    select * from {{ ref('data_right') }}
-)
-select
-    {{ right('string_text', 'length_expression') }} as actual,
-    coalesce(output, '') as expected
-from util_data
-"""
-
-
 class TestRight(BaseRight):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"data_right.csv": seeds__data_right_csv}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "test_right.yml": models__test_right_yml,
-            "test_right.sql": self.interpolate_macro_namespace(models__test_right_sql, "right"),
-        }
+    pass
 
 
 models__test_safe_cast_sql = """


### PR DESCRIPTION
## Describe your changes
For TestRight, the current sql is mentioned below, however with this sql, in the case when length_epression = 0, we are getting NULL in actual column whereas in expected column of test_right we are getting an empty string, which is causing a mismatch between the expected and actual values.

```
create or replace view test_right
  
  as
    with util_data as (
    select * from data_right
)
select
    

    case when length_expression = 0
        then NULL
    else
        substr(
        string_text,
        (length(string_text)-cast(length_expression as int)+1),
        length(string_text)-1
    )
    end as actual,
    coalesce(output, '') as expected
from util_data
```
This PR suggests to update the macro so that instead of NULL we get an empty string in the actual column.


## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-774
## Testing procedure/screenshots(if appropriate):
TestRight in v1.5 - https://gist.github.com/nsharma-25/00c62edbf737b25dae0dffca6ad9dbd5
All Tests in v1.5- https://gist.github.com/nsharma-25/a7368721576fb58593d4163218c5ae4e

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
