### PR TITLE
DBT-776: Add support for different  dateparts in date_trunc macro

### DIFF
--- a/dbt/include/hive/macros/utils/date_trunc.sql
+++ b/dbt/include/hive/macros/utils/date_trunc.sql
@@ -15,5 +15,24 @@
 #}
 
 {% macro hive__date_trunc(datepart, date) -%}
-    trunc({{date}}, '{{datepart}}')
+    {% set datepart_lower = datepart.lower() %}
+    {%- if datepart_lower == 'microseconds' -%}
+        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')
+    {%- elif datepart_lower == 'milliseconds' -%}
+        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss.SSS')
+    {%- elif datepart_lower == 'seconds' -%}
+        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss')
+    {%- elif datepart_lower == 'minutes' -%}
+        date_format({{date}}, 'yyyy-MM-dd HH:mm')
+    {%- elif datepart_lower == 'hours' -%}
+        date_format({{date}}, 'yyyy-MM-dd HH:00')
+    {%- elif datepart_lower == 'day' -%}
+        date_format({{date}}, 'yyyy-MM-dd')
+    {%- elif datepart_lower == 'month' -%}
+        date_format({{date}}, 'yyyy-MM-01')
+    {%- elif datepart_lower == 'year' -%}
+        date_format({{date}}, 'yyyy-01-01')
+    {%- else -%}
+        {{ exceptions.raise_compiler_error("macro date_format not implemented for datepart ~ '" ~ datepart ~ "' ~ on Hive") }}
+    {%- endif -%}
 {%- endmacro %}

--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -295,42 +295,8 @@ class TestDateAdd(BaseDateAdd):
         }
 
 
-models__test_date_trunc_sql = """
-with util_data as (
-
-    select * from {{ ref('data_date_trunc') }}
-
-)
-
-select
-    cast({{date_trunc('day', 'updated_at') }} as date) as actual,
-    day as expected
-
-from util_data
-
-union all
-
-select
-    cast({{ date_trunc('month', 'updated_at') }} as date) as actual,
-    month as expected
-
-from util_data
-"""
-
-
 class TestDateTrunc(BaseDateTrunc):
-    @pytest.fixture(scope="class")
-    def seeds(self):
-        return {"data_date_trunc.csv": seeds__data_date_trunc_csv}
-
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "test_date_trunc.yml": models__test_date_trunc_yml,
-            "test_date_trunc.sql": self.interpolate_macro_namespace(
-                models__test_date_trunc_sql, "date_trunc"
-            ),
-        }
+    pass
 
 
 models__test_escape_single_quotes_quote_sql = """


### PR DESCRIPTION
## Describe your changes
Currently the` date_trunc` macro for TestDateTrunc uses `trunc(string date, string format)` date function in which the supported formats are  MONTH/MON/MM, YEAR/YYYY/YY as mentioned in this doc(https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF#LanguageManualUDF-DateFunctions) and due to this we are getting NULL as the actual value when `datepart='day'`, which leads to inconsistency between the actual and the expected value. 
As a part of this PR, I've updated the date_trunc macro thereby fixing the issue and at the time adding support for different other dateparts like microseconds, milliseconds, etc . I was able to achieve this with the below mentioned macro, where instead of trunc() function, date_format() function has been used.
```
{% macro hive__date_trunc(datepart, date) -%}
    {% set datepart_lower = datepart.lower() %}
    {%- if datepart_lower == 'microseconds' -%}
        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss.SSSSSS')
    {%- elif datepart_lower == 'milliseconds' -%}
        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss.SSS')
    {%- elif datepart_lower == 'seconds' -%}
        date_format({{date}}, 'yyyy-MM-dd HH:mm:ss')
    {%- elif datepart_lower == 'minutes' -%}
        date_format({{date}}, 'yyyy-MM-dd HH:mm')
    {%- elif datepart_lower == 'hours' -%}
        date_format({{date}}, 'yyyy-MM-dd HH:00')
    {%- elif datepart_lower == 'day' -%}
        date_format({{date}}, 'yyyy-MM-dd')
    {%- elif datepart_lower == 'month' -%}
        date_format({{date}}, 'yyyy-MM-01')
    {%- elif datepart_lower == 'year' -%}
        date_format({{date}}, 'yyyy-01-01')
    {%- else -%}
        {{ exceptions.raise_compiler_error("macro date_format not implemented for datepart ~ '" ~ datepart ~ "' ~ on Hive") }}
    {%- endif -%}
{%- endmacro %}

```
## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-776
## Testing procedure/screenshots(if appropriate):
TestDateTrunc(v1.5) -(https://gist.github.com/nsharma-25/c58f7cab9f4e7a86dc34ef5d318d2c29)
TestDateTrunc(v1.6) - (https://gist.github.com/nsharma-25/3312a115ba5004253bd6a83a5b9002cc)
All tests(v1.5) - (https://gist.github.com/nsharma-25/95a7ff67a1a1114cfc3015886c42fde0)
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
