### PR TITLE
DBT-777: Fixing functional tests of TestListagg macro

### DIFF
--- a/tests/functional/adapter/test_utils.py
+++ b/tests/functional/adapter/test_utils.py
@@ -429,15 +429,6 @@ calculate as (
 
     select
         group_col,
-        {{ listagg('string_text', "'_|_'", "order by order_col", 2) }} as actual,
-        'bottom_ordered_limited' as version
-    from util_data
-    group by group_col
-
-    union all
-
-    select
-        group_col,
         {{ listagg('string_text', "', '") }} as actual,
         'comma_whitespace_unordered' as version
     from util_data


### PR DESCRIPTION
## Describe your changes
order_by, limit_num doesn't work for listagg macro of Hive. Hence removing the union all clause for the same.

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-777
## Testing procedure/screenshots(if appropriate):
TestListagg(v1.5)- https://gist.github.com/nsharma-25/3dfa58aa1d38cad6ed183684f47a2eac
TestListagg(v1.6)- https://gist.github.com/nsharma-25/fee30d7a2d982e469667f8b23340c1c3
All Tests(v1.5)-  https://gist.github.com/nsharma-25/161b5473730462ae41124134e9e9a086
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
