### PR TITLE
DBT-778: Upgrade dbt-core version and dbt-hive adapater version to 1.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This code base is now being actively developed and maintained by Cloudera.
 
 ### Requirements
 
-Current version of dbt-hive use dbt-core 1.4.*. We are actively working on supporting the next version of dbt-core 1.5
+Current version of dbt-hive use dbt-core 1.6.*. We are actively working on supporting the next version of dbt-core 1.7
 
 Python >= 3.8
-dbt-core ~= 1.4.*
+dbt-core ~= 1.6.*
 impyla >= 0.18
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This code base is now being actively developed and maintained by Cloudera.
 
 ### Requirements
 
-Current version of dbt-hive use dbt-core 1.6.*. We are actively working on supporting the next version of dbt-core 1.7
+Current version of dbt-hive use dbt-core 1.7.*. We are actively working on supporting the next version of dbt-core 1.8
 
 Python >= 3.8
-dbt-core ~= 1.6.*
+dbt-core ~= 1.7.*
 impyla >= 0.18
 
 ### Install

--- a/dbt/adapters/hive/__version__.py
+++ b/dbt/adapters/hive/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = "1.6.0"
+version = "1.7.0"

--- a/dbt/adapters/hive/column.py
+++ b/dbt/adapters/hive/column.py
@@ -16,7 +16,6 @@ from typing import TypeVar, Optional, Dict, Any
 
 from dbt.adapters.base.column import Column
 from dbt.dataclass_schema import dbtClassMixin
-from hologram import JsonDict
 
 Self = TypeVar("Self", bound="HiveColumn")
 
@@ -71,7 +70,7 @@ class HiveColumn(dbtClassMixin, Column):
     #                 table_stats[f'stats:{key}:include'] = True
     #         return table_stats
 
-    def to_column_dict(self, omit_none: bool = True, validate: bool = False) -> JsonDict:
+    def to_column_dict(self, omit_none: bool = True, validate: bool = False):
         original_dict = self.to_dict(omit_none=omit_none)
         # If there are stats, merge them into the root of the dict
         # original_stats = original_dict.pop('table_stats', None)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.6.*
+dbt-tests-adapter==1.7.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-hive"
 # make sure this always matches dbt/adapters/hive/__version__.py
-package_version = "1.6.0"
+package_version = "1.7.0"
 description = """The Hive adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()


### PR DESCRIPTION
## Describe your changes
Upgrade dbt-core version and dbt-hive adapater version to 1.7

dbt-core has removed hologram dependency as part of this PR: https://github.com/dbt-labs/dbt-core/pull/8437/files
Hence removing it from dbt-hive too.

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-778
## Testing procedure/screenshots(if appropriate):
https://gist.github.com/nsharma-25/d1d1b7efe99539a9c92234bb2238cab4
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
