### PR TITLE
Add "krb_host" as a config option

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -65,6 +65,7 @@ class HiveCredentials(Credentials):
     use_http_transport: Optional[bool] = True
     http_path: Optional[str] = None
     kerberos_service_name: Optional[str] = None
+    krb_host: Optional[str] = None
     usage_tracking: Optional[bool] = True  # usage tracking is enabled by default
 
     _ALIASES = {"pass": "password", "user": "username"}
@@ -226,6 +227,7 @@ class HiveConnectionManager(SQLConnectionManager):
                     port=credentials.port,
                     auth_mechanism="GSSAPI",
                     kerberos_service_name=credentials.kerberos_service_name,
+                    krb_host=credentials.krb_host,
                     use_http_transport=credentials.use_http_transport,
                     use_ssl=credentials.use_ssl,
                     ca_cert=credentials.ca_cert,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,7 @@ def cdh_kerberos_target():
         "port": int(os.getenv("DBT_HIVE_PORT")),
         "schema": os.getenv("DBT_HIVE_SCHEMA") or "dbt_adapter_test",
         "kerberos_service_name": os.getenv("DBT_HIVE_KERBEROS_SERVICE_NAME") or "hive",
+        "krb_host": os.getenv("DBT_HIVE_KRB_HOST") or None,
         "use_http_transport": bool(strtobool(os.getenv("DBT_HIVE_USE_HTTP_TRANSPORT") or "f")),
         "use_ssl": bool(strtobool(os.getenv("DBT_HIVE_USE_SSL") or "f")),
         "ca_cert": os.getenv("DBT_CA_CERT") or None,


### PR DESCRIPTION
## Describe your changes
Added "krb_host" as an optional parameter for Hive connections that use Kerberos as their authentication type.

## Internal Jira ticket number or external issue link
Issue from @Mac-lp3  https://github.com/cloudera/dbt-hive/issues/153

## Testing procedure/screenshots(if appropriate):

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
