### PR TITLE
DBT-783 Support dbt-core 1.8.0 for dbt-hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This code base is now being actively developed and maintained by Cloudera.
 
 ### Requirements
 
-Current version of dbt-hive use dbt-core 1.7.*. We are actively working on supporting the next version of dbt-core 1.8
+Current version of dbt-hive uses dbt-core 1.8.*. We are actively working on supporting the next available version of dbt-core.
 
 Python >= 3.8
-dbt-core ~= 1.7.*
+dbt-core ~= 1.8.*
 impyla >= 0.18
 
 ### Install

--- a/dbt/adapters/hive/__version__.py
+++ b/dbt/adapters/hive/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = "1.7.0"
+version = "1.8.0"

--- a/dbt/adapters/hive/cloudera_tracking.py
+++ b/dbt/adapters/hive/cloudera_tracking.py
@@ -23,8 +23,8 @@ import hashlib
 import threading
 from dbt.tracking import active_user
 
-from dbt.adapters.base import Credentials
-from dbt.events import AdapterLogger
+from dbt.adapters.contracts.connection import Credentials
+from dbt.adapters.events.logging import AdapterLogger
 from decouple import config
 
 

--- a/dbt/adapters/hive/column.py
+++ b/dbt/adapters/hive/column.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from typing import TypeVar, Optional, Dict, Any
 
 from dbt.adapters.base.column import Column
-from dbt.dataclass_schema import dbtClassMixin
+from dbt_common.dataclass_schema import dbtClassMixin
 
 Self = TypeVar("Self", bound="HiveColumn")
 

--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -17,20 +17,21 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Optional, Tuple
+from multiprocessing.context import SpawnContext
 
 import dbt.exceptions
 import impala.dbapi
-from dbt.adapters.base import Credentials
+from dbt.adapters.contracts.connection import Credentials
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import (
+from dbt.adapters.contracts.connection import (
     AdapterResponse,
     AdapterRequiredConfig,
     Connection,
     ConnectionState,
 )
-from dbt.events import AdapterLogger
-from dbt.events.functions import fire_event
-from dbt.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
+from dbt.adapters.events.logging import AdapterLogger
+from dbt_common.events.functions import fire_event
+from dbt.adapters.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.utils import DECIMALS
 
 import json
@@ -181,8 +182,8 @@ class HiveConnectionManager(SQLConnectionManager):
 
     hive_version = None
 
-    def __init__(self, profile: AdapterRequiredConfig):
-        super().__init__(profile)
+    def __init__(self, profile: AdapterRequiredConfig, mp_context: SpawnContext):
+        super().__init__(profile, mp_context)
         # generate profile related object for instrumentation.
         tracker.generate_profile_info(self)
 

--- a/dbt/adapters/hive/relation.py
+++ b/dbt/adapters/hive/relation.py
@@ -16,7 +16,7 @@ from typing import Optional
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
-from dbt.exceptions import DbtRuntimeError
+from dbt_common.exceptions import DbtRuntimeError
 import dbt.adapters.hive.cloudera_tracking as tracker
 
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.7.*
+dbt-tests-adapter==1.8.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-hive"
 # make sure this always matches dbt/adapters/hive/__version__.py
-package_version = "1.7.0"
+package_version = "1.8.0"
 description = """The Hive adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()


### PR DESCRIPTION
## Describe your changes
Upgraded dbt-hive adapter to support dbt-core version of 1.8.*. The [migration guide
](https://github.com/dbt-labs/dbt-adapters/discussions/87) and this [PR](https://github.com/cloudera/dbt-hive/pull/149) were used as a reference. As suggested by the migration guide following changes were done 
- imports were shifted to new module/package structure of dbt-core. 
- functional/semantic code changes to reflect new method signatures. 

No changes to tests and macros were required at this point. 

@vamshikolanu 
In one of the test classes, I came across a file called manifest.json, is this the same manifest file that is required by adapter to access database objects? 

## Internal Jira ticket number or external issue link
https://jira.cloudera.com/browse/DBT-783

## Testing procedure/screenshots(if appropriate)

Tests run on all python versions 

https://gist.github.com/niranjancdw/c2440c68ce21c46e1e3fc0bce4145d2b

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
