### PR TITLE
DBT-847 Support dbt-core 1.11.0 for dbt-hive

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ This code base is now being actively developed and maintained by Cloudera.
 
 ### Requirements
 
-Current version of dbt-hive uses dbt-core 1.10.*. We are actively working on supporting the next available version of dbt-core.
+Current version of dbt-hive uses dbt-core 1.11.*. We are actively working on supporting the next available version of dbt-core.
 
-Python >= 3.9
-dbt-core ~= 1.10.*
+Python >= 3.10
+dbt-core ~= 1.11.*
 impyla == 0.22
 
 ### Install

--- a/dbt/adapters/hive/__version__.py
+++ b/dbt/adapters/hive/__version__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-version = "1.10.0"
+version = "1.11.0"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-dbt-tests-adapter==1.10.*
+dbt-tests-adapter==1.19.*
 pre-commit~=2.21;python_version=="3.7"
 pre-commit~=3.2;python_version>="3.8"
 pytest

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def _get_dbt_core_version():
 
 package_name = "dbt-hive"
 # make sure this always matches dbt/adapters/hive/__version__.py
-package_version = "1.10.0"
+package_version = "1.11.0"
 description = """The Hive adapter plugin for dbt"""
 
 dbt_core_version = _get_dbt_core_version()


### PR DESCRIPTION
## Describe your changes
Upgraded dbt-hive adapter to support dbt-core version of 1.11.*

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-847

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/niranjancdw/838e760049501b1331aea7096dc7845b

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.
