### PR TITLE
fix: correct typo in DbtDatabaseError exception name (#178)

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -278,7 +278,7 @@ class HiveConnectionManager(SQLConnectionManager):
             )
         except HiveServer2Error as hiveError:
             logger.debug(f"Server connection error: {hiveError}")
-            raise DbtDatbaseError(
+            raise DbtDatabaseError(
                 "Unable to establish connection to Hive server: " + str(hiveError)
             )
         except Exception as exc:


### PR DESCRIPTION
# Summary

This MR fixes a typo in the exception class name used in `dbt/adapters/hive/connections.py`.

The code currently raises `DbtDatbaseError`, while the correct exception class name is `DbtDatabaseError`.

# Changes

* Replace `DbtDatbaseError` with `DbtDatabaseError` in `connections.py`.

# Related Issue

Fixes #178 

# Notes

This is a small typo fix intended to ensure the correct exception class is referenced and to prevent potential runtime errors when this code path is executed.
