### PR TITLE
DBT-832: Added support and test for constraints in dbt-hive

### DIFF
--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -479,3 +479,7 @@ class HiveConnectionManager(SQLConnectionManager):
                     "The config '{}' is required when using the {} method"
                     " to connect to Hive".format(key, method)
                 )
+
+    @classmethod
+    def data_type_code_to_name(cls, type_code) -> str:
+        return type_code.split("(")[0].upper()

--- a/dbt/adapters/hive/connections.py
+++ b/dbt/adapters/hive/connections.py
@@ -278,7 +278,7 @@ class HiveConnectionManager(SQLConnectionManager):
             )
         except HiveServer2Error as hiveError:
             logger.debug(f"Server connection error: {hiveError}")
-            raise DbtDatbaseError(
+            raise DbtDatabaseError(
                 "Unable to establish connection to Hive server: " + str(hiveError)
             )
         except Exception as exc:

--- a/dbt/include/hive/macros/adapters.sql
+++ b/dbt/include/hive/macros/adapters.sql
@@ -120,36 +120,80 @@
 
 {% macro hive__create_table_as(temporary, relation, sql) -%}
   {%- set _properties = config.get('tbl_properties') -%}
-  {%- set is_external = config.get('external') -%}
+  {%- set is_external = config.get('external', default=false) -%}
   {%- set table_type = config.get('table_type') -%}
+  {%- set contract_config = config.get('contract', default={'enforced': false}) -%}
+  {%- set file_format = config.get('file_format') -%}
 
-  {% if temporary -%}
+  {%- if temporary -%}
     {{ create_temporary_view(relation, sql) }}
   {%- else -%}
-    {% if config.get('file_format', validator=validation.any[basestring]) == 'delta' %}
-      create or replace table {{ relation }}
-    {% else %}
-      create {% if is_external == true -%}external{%- endif %} table {{ relation }}
-    {% endif %}
-    {{ options_clause() }}
-    {% if table_type == 'iceberg' -%}
-      {{ partition_cols(label="partitioned by spec") }}
-    {% else %}
-      {{ partition_cols(label="partitioned by") }}
-    {%- endif %}
-    {{ clustered_cols(label="clustered by") }}
-    {{ stored_by_clause(table_type) }}
-    {{ file_format_clause() }}
-    {{ location_clause() }}
-    {{ comment_clause() }}
-    {{ properties_clause(_properties) }}
-    as
-      {{ sql }}
+
+    {# -- Capture DDL clauses into a variable -- #}
+    {%- set ddl_clauses -%}
+      {{ options_clause() }}
+      {% if table_type == 'iceberg' -%}
+        {{ partition_cols(label="partitioned by spec") }}
+      {%- else -%}
+        {{ partition_cols(label="partitioned by") }}
+      {%- endif %}
+      {{ clustered_cols(label="clustered by") }}
+      {{ stored_by_clause(table_type) }}
+      {{ file_format_clause() }}
+      {{ location_clause() }}
+      {{ comment_clause() }}
+      {{ properties_clause(_properties) }}
+    {%- endset -%}
+
+    {%- if contract_config.enforced -%}
+      {# -- CASE 1: ENFORCED CONTRACT -- #}
+      {% do get_assert_columns_equivalent(sql) %}
+
+      create {% if is_external %}external{%- endif %} table {{ relation }} (
+        {%- for column_name, column_dict in model['columns'].items() -%}
+          {%- set safe_col = "`" ~ column_name ~ "`" if column_name | lower in ['from', 'to', 'all', 'select', 'table', 'order', 'group', 'by', 'where', 'limit'] else column_name -%}
+          {{ safe_col }} {{ column_dict.data_type }}
+          {%- if column_dict.constraints -%}
+            {%- for constraint in column_dict.constraints -%}
+              {%- if constraint.type == 'not_null' %} NOT NULL{%- endif -%}
+            {%- endfor -%}
+          {%- endif -%}
+          {{ "," if not loop.last }}
+        {%- endfor -%}
+      )
+      {{ ddl_clauses }};
+
+      insert into {{ relation }} (
+        {%- for column_name in model['columns'].keys() -%}
+          {{ "`" ~ column_name ~ "`" if column_name | lower in ['from', 'to', 'all', 'select', 'table', 'order', 'group', 'by', 'where', 'limit'] else column_name }}{{ "," if not loop.last }}
+        {%- endfor -%}
+      )
+      {{ get_select_subquery(sql) }}
+
+    {%- else -%}
+      {# -- CASE 2: STANDARD CTAS -- #}
+      {%- set create_stmt = "create or replace table" if file_format == 'delta' else "create " ~ ("external " if is_external else "") ~ "table" -%}
+
+      {{ create_stmt }} {{ relation }}
+      {{ ddl_clauses }}
+      as
+        {{ sql }}
+    {%- endif -%}
+
   {%- endif %}
 {%- endmacro -%}
 
 
+
 {% macro hive__create_view_as(relation, sql) -%}
+  {%- set contract_config = config.get('contract') -%}
+
+  {# -- Contract enforcement -- #}
+  {%- if contract_config.enforced -%}
+    {{ get_assert_columns_equivalent(sql) }}
+    {%- set sql = get_select_subquery(sql) -%}
+  {%- endif -%}
+
   create or replace view {{ relation }}
   {{ comment_clause() }}
   as

--- a/dbt/include/hive/macros/materializations/table.sql
+++ b/dbt/include/hive/macros/materializations/table.sql
@@ -17,35 +17,39 @@
 {% materialization table, adapter = 'hive' %}
 
   {%- set identifier = model['alias'] -%}
-
   {%- set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) -%}
-  {%- set target_relation = api.Relation.create(identifier=identifier,
-                                                schema=schema,
-                                                database=database,
-                                                type='table') -%}
+  {%- set target_relation = api.Relation.create(identifier=identifier, schema=schema, database=database, type='table') -%}
 
   {{ run_hooks(pre_hooks) }}
 
-  -- grab current tables grants config for comparision later on
+ {%- set table_type = config.get('table_type', '') | lower -%}
+  {% if table_type == 'iceberg' %}
+      {% if old_relation %}
+          {{ adapter.drop_relation(old_relation) }}
+      {% endif %}
+      {% call statement('main') -%}
+          {{ create_table_as(False, target_relation, sql) }}
+      {%- endcall %}
+
+  {% else %}
+
+      {%- set tmp_relation = target_relation.incorporate(path={"identifier": identifier ~ "__dbt_tmp"}) -%}
+
+      {% call statement('main') -%}
+          {{ create_table_as(False, tmp_relation, sql) }}
+      {%- endcall %}
+
+      {% if old_relation %}
+          {{ adapter.drop_relation(old_relation) }}
+      {% endif %}
+
+      {{ adapter.rename_relation(tmp_relation, target_relation) }}
+  {% endif %}
+
   {% set grant_config = config.get('grants') %}
-
-  -- setup: if the target relation already exists, drop it
-  -- in case if the existing and future table is delta, we want to do a
-  -- create or replace table instead of dropping, so we don't have the table unavailable
-  {% if old_relation and not (old_relation.is_delta and config.get('file_format', validator=validation.any[basestring]) == 'delta') -%}
-    {{ adapter.drop_relation(old_relation) }}
-  {%- endif %}
-
-  -- build model
-  {% call statement('main') -%}
-    {{ create_table_as(False, target_relation, sql) }}
-  {%- endcall %}
-
-  {% set should_revoke = should_revoke(existing_relation, full_refresh_mode=True) %}
+  {% set should_revoke = should_revoke(target_relation, full_refresh_mode=True) %}
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
-
   {% do persist_docs(target_relation, model) %}
-
   {{ run_hooks(post_hooks) }}
 
   {{ return({'relations': [target_relation]})}}

--- a/dbt/include/hive/macros/relations/column/columns_spec_ddl.sql
+++ b/dbt/include/hive/macros/relations/column/columns_spec_ddl.sql
@@ -1,0 +1,43 @@
+{% macro hive__assert_columns_equivalent(sql) %}
+
+  {%- set user_defined_columns = model['columns'] -%}
+  {%- if not user_defined_columns -%}
+      {{ exceptions.raise_contract_error([], []) }}
+  {%- endif -%}
+
+  {%- set sql_file_provided_columns = get_column_schema_from_query(sql, config.get('sql_header', none)) -%}
+
+  {%- set schema_file_provided_columns = get_column_schema_from_query(get_empty_schema_sql(user_defined_columns)) -%}
+
+  {%- set sql_columns = format_columns(sql_file_provided_columns) -%}
+  {%- set yaml_columns = format_columns(schema_file_provided_columns)  -%}
+
+  {%- if sql_columns|length != yaml_columns|length -%}
+    {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
+  {%- endif -%}
+
+  {%- for sql_col in sql_columns -%}
+    {%- set yaml_col = [] -%}
+
+    {%- for this_col in yaml_columns -%}
+      {%- if this_col['name'] | lower == sql_col['name'] | lower -%}
+        {%- do yaml_col.append(this_col) -%}
+        {%- break -%}
+      {%- endif -%}
+    {%- endfor -%}
+
+    {%- if not yaml_col -%}
+      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
+    {%- endif -%}
+
+    {%- set sql_type = sql_col['formatted'] | upper | trim -%}
+    {%- set yaml_type = yaml_col[0]['formatted'] | upper | trim -%}
+
+
+    {%- if sql_type != yaml_type -%}
+      {%- do exceptions.raise_contract_error(yaml_columns, sql_columns) -%}
+    {%- endif -%}
+
+  {%- endfor -%}
+
+{% endmacro %}

--- a/dbt/include/hive/macros/utils/column.sql
+++ b/dbt/include/hive/macros/utils/column.sql
@@ -1,0 +1,40 @@
+{% macro hive__get_empty_subquery_sql(select_sql, select_sql_header=none) %}
+    {%- if select_sql_header is not none -%}
+    {{ select_sql_header }}
+    {%- endif -%}
+    select * from (
+        {{ select_sql }}
+    ) as dbt_sbq
+    where false
+    limit 0
+{% endmacro %}
+
+{% macro hive__get_empty_schema_sql(columns) %}
+    {%- set col_err = [] -%}
+    select
+    {%- for i in columns %}
+      {%- set col = columns[i] -%}
+      {%- if col['data_type'] is not defined -%}
+        {{ col_err.append(col['name']) }}
+      {%- else -%}
+        {%- set col_name = adapter.quote(col['name']) if col.get('quote') else col['name'] -%}
+        {%- set dtype = col['data_type'] | lower -%}
+
+        {# To represent "null" for complex types #}
+        {%- if dtype.startswith('array') -%}
+          {%- set null_expr = "array(null)" -%}
+        {%- elif dtype.startswith('map') -%}
+          {%- set null_expr = "map(null, null)" -%}
+        {%- else -%}
+          {%- set null_expr = "null" -%}
+        {%- endif -%}
+
+        {{ "  " }}cast({{ null_expr }} as {{ dtype }}) as {{ col_name }}
+        {%- if not loop.last -%},{{ "\n" }}{%- endif -%}
+      {%- endif -%}
+    {%- endfor %}
+
+    {%- if (col_err | length) > 0 -%}
+      {{ exceptions.column_type_missing(column_names=col_err) }}
+    {%- endif -%}
+{% endmacro %}

--- a/tests/functional/adapter/constraints/test_constraints.py
+++ b/tests/functional/adapter/constraints/test_constraints.py
@@ -1,0 +1,248 @@
+import pytest
+from dbt.tests.adapter.constraints.test_constraints import (
+    BaseModelConstraintsRuntimeEnforcement,
+    BaseTableConstraintsColumnsEqual,
+    BaseViewConstraintsColumnsEqual,
+    BaseIncrementalConstraintsColumnsEqual,
+    BaseConstraintsRuntimeDdlEnforcement,
+    BaseConstraintsRollback,
+    BaseIncrementalConstraintsRuntimeDdlEnforcement,
+    BaseIncrementalConstraintsRollback,
+    BaseConstraintQuotedColumn,
+)
+
+from dbt.tests.adapter.constraints.fixtures import (
+    constrained_model_schema_yml,
+    model_schema_yml,
+    my_model_sql,
+    my_model_wrong_order_sql,
+    my_model_wrong_name_sql,
+    my_model_view_wrong_order_sql,
+    my_model_view_wrong_name_sql,
+    my_model_incremental_wrong_order_sql,
+    my_model_incremental_wrong_name_sql,
+    my_incremental_model_sql,
+    model_fk_constraint_schema_yml,
+    my_model_wrong_order_depends_on_fk_sql,
+    foreign_key_model_sql,
+    my_model_incremental_wrong_order_depends_on_fk_sql,
+    my_model_with_quoted_column_name_sql,
+    model_quoted_column_schema_yml,
+)
+
+# Hive-Specific Expected SQL & Model Adjustments
+_expected_sql_hive = """
+create table <model_identifier>(id integer not null,color string,date_day string)
+stored as parquet ;
+insert into <model_identifier>(id,color,date_day)
+select id,color,date_day from(
+-- depends_on: <foreign_key_model_identifier>
+select 'blue' as color,1 as id,'2019-01-01' as date_day
+)as model_subq
+"""
+
+# Hive does not support a 'text' data type so using 'string'
+constraints_yml = model_schema_yml.replace("text", "string")
+fk_constraints_yml = model_fk_constraint_schema_yml.replace("text", "string")
+model_constraints_yml = constrained_model_schema_yml.replace("text", "string")
+
+
+class HiveSetup:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "models": {
+                "+file_format": "parquet",
+            }
+        }
+
+    @pytest.fixture
+    def string_type(self):
+        return "STRING"
+
+    @pytest.fixture
+    def int_type(self):
+        return "INT"
+
+    @pytest.fixture
+    def schema_string_type(self):
+        return "STRING"
+
+    @pytest.fixture
+    def schema_int_type(self):
+        return "INT"
+
+    @pytest.fixture
+    def data_types(self, int_type, schema_int_type, string_type, schema_string_type):
+        return [
+            ["1", schema_int_type, int_type],
+            ["'1'", string_type, string_type],
+            ["true", "boolean", "BOOLEAN"],
+            ["CAST('2013-11-03 00:00:00' AS timestamp)", "timestamp", "TIMESTAMP"],
+            ["CAST(1.23 AS decimal(10,2))", "decimal(10,2)", "DECIMAL"],
+            ["ARRAY('a','b','c')", "ARRAY<STRING>", "ARRAY"],
+            ["MAP('bar','baz')", "map<string,string>", "MAP"],
+        ]
+
+
+# ------------------------------------------------------------------------------
+# Hive Column Equality Tests
+# ------------------------------------------------------------------------------
+class TestHiveTableConstraintsColumnsEqual(HiveSetup, BaseTableConstraintsColumnsEqual):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_wrong_name_sql,
+            "constraints_schema.yml": constraints_yml,
+        }
+
+
+class TestHiveViewConstraintsColumnsEqual(HiveSetup, BaseViewConstraintsColumnsEqual):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_view_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_view_wrong_name_sql,
+            "constraints_schema.yml": constraints_yml,
+        }
+
+
+class TestHiveIncrementalConstraintsColumnsEqual(
+    HiveSetup, BaseIncrementalConstraintsColumnsEqual
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model_wrong_order.sql": my_model_incremental_wrong_order_sql,
+            "my_model_wrong_name.sql": my_model_incremental_wrong_name_sql,
+            "constraints_schema.yml": constraints_yml,
+        }
+
+
+# ------------------------------------------------------------------------------
+# Hive DDL Constraint Enforcement Tests
+# ------------------------------------------------------------------------------
+class BaseHiveConstraintsDdlEnforcementSetup:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+file_format": "parquet"}}
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return _expected_sql_hive
+
+
+class TestHiveTableConstraintsDdlEnforcement(
+    BaseHiveConstraintsDdlEnforcementSetup, BaseConstraintsRuntimeDdlEnforcement
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fk_constraints_yml,
+        }
+
+
+class TestHiveIncrementalConstraintsDdlEnforcement(
+    BaseHiveConstraintsDdlEnforcementSetup, BaseIncrementalConstraintsRuntimeDdlEnforcement
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_incremental_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fk_constraints_yml,
+        }
+
+
+# ------------------------------------------------------------------------------
+# Hive Quoted Column Constraint Test
+# ------------------------------------------------------------------------------
+class TestHiveConstraintQuotedColumn(HiveSetup, BaseConstraintQuotedColumn):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_with_quoted_column_name_sql,
+            "constraints_schema.yml": model_quoted_column_schema_yml.replace(
+                "text", "string"
+            ).replace('"from"', "`from`"),
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return """
+  create table <model_identifier>(id integer not null ,`from` string not null,date_day string)
+stored as parquet ;
+insert into <model_identifier>(id,`from`,date_day)
+select id,`from`,date_day from(
+select 'blue' as `from`,1 as id,'2019-01-01' as date_day
+)as model_subq
+"""
+
+
+# ------------------------------------------------------------------------------
+# Hive Constraint Rollback Tests
+# ------------------------------------------------------------------------------
+class BaseHiveConstraintsRollbackSetup:
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+file_format": "orc", "+contract": {"enforced": True}}}
+
+    @pytest.fixture(scope="class")
+    def expected_error_messages(self):
+        return [
+            "Constraint violation",
+            "NOT NULL constraint violated",
+            "CHECK constraint failed",
+            "column is null",
+        ]
+
+    def assert_expected_error_messages(self, error_message, expected_error_messages):
+        assert any(msg in error_message for msg in expected_error_messages)
+
+
+class TestHiveTableConstraintsRollback(BaseHiveConstraintsRollbackSetup, BaseConstraintsRollback):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_sql,
+            "constraints_schema.yml": constraints_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_color(self):
+        return "blue"
+
+
+class TestHiveIncrementalConstraintsRollback(
+    BaseHiveConstraintsRollbackSetup, BaseIncrementalConstraintsRollback
+):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_incremental_model_sql,
+            "constraints_schema.yml": constraints_yml,
+        }
+
+
+# ------------------------------------------------------------------------------
+# Hive Model-Level Runtime Enforcement
+# ------------------------------------------------------------------------------
+class TestHiveModelConstraintsRuntimeEnforcement(BaseModelConstraintsRuntimeEnforcement):
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"models": {"+file_format": "parquet"}}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "my_model.sql": my_model_wrong_order_depends_on_fk_sql,
+            "foreign_key_model.sql": foreign_key_model_sql,
+            "constraints_schema.yml": fk_constraints_yml,
+        }
+
+    @pytest.fixture(scope="class")
+    def expected_sql(self):
+        return _expected_sql_hive

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skipsdist = True
 envlist = py310,py311,py312,py313
 
-[testenv:{py39,py310,py311}]
+[testenv:{py310,py311,py312,py313}]
 description = adapter plugin integration and unit testing
 skip_install = true
 passenv =


### PR DESCRIPTION
## Describe your changes
- Updated the python versions in testenv.
- Corrected a typo in connections.py. 
- Introduced logic to check for contract: {enforced: true}.
- Shifted from a single CTAS step to a two-step Explicit Create + Insert process.
- Implemented automatic backtick wrapping for column names that conflict with SQL keywords.
- Added support for applying NOT NULL constraints during the table creation phase based on the model's YAML definitions.
- Updated the Python adapter's data_type_code_to_name method to standardize type strings by removing precision/scale. (e.g., DECIMAL(10,2) to DECIMAL). 
- Refined hive__on_table_exists_logic to ensure consistent handling of rename, drop, and replace operations across both Iceberg and standard Hive table formats.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-832

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/MonikaK2409/fb3e99c68566d67741709ff21d4087ac

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.