### PR TITLE
DBT-855: Added persist_doc support in dbt-hive

### DIFF
--- a/dbt/adapters/hive/column.py
+++ b/dbt/adapters/hive/column.py
@@ -31,6 +31,7 @@ class HiveColumn(dbtClassMixin, Column):
     table_owner: Optional[str] = None
     table_stats: Optional[Dict[str, Any]] = None
     column_index: Optional[int] = None
+    comment: Optional[str] = None
 
     @classmethod
     def translate_type(cls, dtype: str) -> str:

--- a/dbt/adapters/hive/impl.py
+++ b/dbt/adapters/hive/impl.py
@@ -225,6 +225,28 @@ class HiveAdapter(SQLAdapter):
                 unique_rows.append(row)
         return unique_rows
 
+    def _hive_describe_row_comment(self, column_row) -> Optional[str]:
+        """
+        Helper function to safely read and extract the column comment string
+        from a Hive 'DESCRIBE FORMATTED' row object. (Read-only)
+        """
+        if column_row is None:
+            return None
+        keys = getattr(column_row, "_keys", None)
+        values = getattr(column_row, "_values", None)
+        row = (
+            dict(zip(keys, values))
+            if keys is not None and values is not None
+            else dict(column_row)
+        )
+        raw = row.get("comment")
+        if raw is None:
+            raw = row.get("Comment")
+        if raw is None:
+            return None
+        text = str(raw).strip()
+        return text if text else None
+
     def parse_describe_formatted(
         self, relation: Relation, raw_rows: List[agate.Row]
     ) -> List[HiveColumn]:
@@ -277,6 +299,7 @@ class HiveAdapter(SQLAdapter):
                 column=column["col_name"],
                 column_index=idx,
                 dtype=column["data_type"],
+                comment=self._hive_describe_row_comment(column),
             )
             for idx, column in enumerate(rows)
         ]
@@ -329,17 +352,32 @@ class HiveAdapter(SQLAdapter):
         return columns
 
     def _get_columns_for_catalog(self, relation: HiveRelation) -> Iterable[Dict[str, Any]]:
-        """Get columns for catalog. Used by get_one_catalog"""
-        # columns = self.parse_columns_from_information(relation)
         columns = self.get_columns_in_relation(relation)
+        table_comment = self._table_comment_from_properties(relation)
 
         for column in columns:
-            # convert HiveColumns into catalog dicts
             as_dict = column.to_column_dict()
             as_dict["column_name"] = as_dict.pop("column", None)
             as_dict["column_type"] = as_dict.pop("dtype")
             as_dict["table_database"] = None
+            as_dict["column_comment"] = column.comment
+            as_dict["table_comment"] = table_comment
+
             yield as_dict
+
+    def _table_comment_from_properties(self, relation: HiveRelation) -> Optional[str]:
+        """
+        Helper function to extract the table-level 'comment' property
+        from Hive table properties metadata. (Read-only)
+        """
+        props = self.get_properties(relation)
+        if not props:
+            return None
+        raw = props.get("comment") or props.get("COMMENT")
+        if raw is None:
+            return None
+        text = str(raw).strip()
+        return text if text else None
 
     def get_properties(self, relation: Relation) -> Dict[str, str]:
         """ """

--- a/dbt/include/hive/macros/adapters.sql
+++ b/dbt/include/hive/macros/adapters.sql
@@ -46,7 +46,8 @@
   {%- if raw_persist_docs is mapping -%}
     {%- set raw_relation = raw_persist_docs.get('relation', false) -%}
       {%- if raw_relation -%}
-      comment '{{ model.description | replace("'", "\\'") }}'
+       {% set escaped_description = model.description | replace("'", "\\'") | replace("\n", " ") | replace("\r", " ") | replace(";", ":")  %}
+       comment '{{ escaped_description }}'
       {% endif %}
   {%- else -%}
     {{ exceptions.raise_compiler_error("Invalid value provided for 'persist_docs'. Expected dict but got value: " ~ raw_persist_docs) }}
@@ -132,6 +133,7 @@
     {# -- Capture DDL clauses into a variable -- #}
     {%- set ddl_clauses -%}
       {{ options_clause() }}
+      {{ comment_clause() }}
       {% if table_type == 'iceberg' -%}
         {{ partition_cols(label="partitioned by spec") }}
       {%- else -%}
@@ -141,7 +143,6 @@
       {{ stored_by_clause(table_type) }}
       {{ file_format_clause() }}
       {{ location_clause() }}
-      {{ comment_clause() }}
       {{ properties_clause(_properties) }}
     {%- endset -%}
 
@@ -195,6 +196,7 @@
   {%- endif -%}
 
   create or replace view {{ relation }}
+  {{ hive__view_column_comment_list(sql) }}
   {{ comment_clause() }}
   as
     {{ sql }}
@@ -272,19 +274,62 @@
   {% endif %}
 {% endmacro %}
 
+{#
+  Executes DDL statements to alter column comments in Hive.
+  Unlike standard SQL, Hive requires re-specifying the column name and data type
+  along with the comment: ALTER TABLE/VIEW <rel> CHANGE COLUMN <col> <col> <type> COMMENT '...'.
+  (Write / DDL operation)
+#}
 {% macro hive__alter_column_comment(relation, column_dict) %}
-  {% if config.get('file_format', validator=validation.any[basestring]) == 'delta' %}
-    {% for column_name in column_dict %}
-      {% set comment = column_dict[column_name]['description'] %}
-      {% set escaped_comment = comment | replace('\'', '\\\'') %}
-      {% set comment_query %}
-        alter table {{ relation }} change column
-            {{ adapter.quote(column_name) if column_dict[column_name]['quote'] else column_name }}
-            comment '{{ escaped_comment }}';
-      {% endset %}
-      {% do run_query(comment_query) %}
-    {% endfor %}
+  {% set existing_cols = adapter.get_columns_in_relation(relation) %}
+  {% set type_by_name = {} %}
+  {% for col in existing_cols %}
+    {% do type_by_name.update({(col.name | lower): col.data_type}) %}
+  {% endfor %}
+  {% for column_name in column_dict %}
+    {% set col_config = column_dict[column_name] %}
+    {% set comment = col_config.get('description') %}
+    {% if comment %}
+      {% set hive_type = col_config.get('data_type') or type_by_name.get(column_name | lower) %}
+      {% if hive_type %}
+        {% set quoted_name = adapter.quote(column_name) if col_config.get('quote') else column_name %}
+        {% set escaped_comment = comment | replace("'", "\\'") | replace("\n", " ") | replace("\r", " ") | replace(";", ":") %}
+        {% set comment_query %}
+          alter {{relation.type}} {{ relation }} change column {{ quoted_name }} {{ quoted_name }} {{ hive_type }} comment '{{ escaped_comment }}'
+        {% endset %}
+        {% do run_query(comment_query) %}
+      {% endif %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}
+
+{#
+  Generates a list of column comment SQL expressions specifically for VIEW definitions in Hive.
+
+  Note: Native Hive does not support 'ALTER VIEW ... CHANGE COLUMN' to update
+  individual column comments after a view exists. Therefore, this macro builds
+  the column comments directly into the view creation query (CREATE VIEW ... (col COMMENT '...')).
+  (Write / DDL helper operation)
+#}
+{% macro hive__view_column_comment_list(sql) %}
+  {% if not config.persist_column_docs() or not model.columns %}
+    {{ return('') }}
   {% endif %}
+
+  {% set physical_cols = adapter.get_column_schema_from_query(sql) %}
+  (
+    {%- for col in physical_cols -%}
+      {% set col_config = model.columns.get(col.name) %}
+      {% set col_name = adapter.quote(col.name) if col_config and col_config.get('quote') else col.name %}
+      {% if col_config and col_config.get('description') %}
+        {% set escaped = col_config.get('description') | replace("'", "\\'") | replace("\n", " ") | replace("\r", " ") | replace(";", ":") %}
+        {{ col_name }} COMMENT '{{ escaped }}'
+      {% else %}
+        {{ col_name }}
+      {% endif %}
+      {%- if not loop.last -%}, {% endif -%}
+    {%- endfor -%}
+  )
 {% endmacro %}
 
 {% macro hive__list_tables_without_caching(schema) %}

--- a/tests/functional/adapter/test_persist_docs.py
+++ b/tests/functional/adapter/test_persist_docs.py
@@ -1,0 +1,33 @@
+from dbt.tests.adapter.persist_docs.test_persist_docs import (
+    BasePersistDocs,
+    BasePersistDocsColumnMissing,
+    BasePersistDocsCommentOnQuotedColumn,
+)
+
+
+class BasePersistDocsHiveCompat(BasePersistDocs):
+    """Hive often returns relation/column comments as a single line from metastore."""
+
+    def _assert_common_comments(self, *comments):
+        for comment in comments:
+            assert comment is not None
+            assert "with double quotes" in comment
+            assert "abc123" in comment
+            assert "Some $lbl$ labeled $lbl$ and $$ unlabeled $$ dollar-quoting" in comment
+            assert "/* comment */" in comment
+            if "\n" in comment:
+                pass
+            else:
+                assert "statistics are made up" in comment or "reserved -- characters" in comment
+
+
+class TestPersistDocsHive(BasePersistDocsHiveCompat):
+    pass
+
+
+class TestPersistDocsColumnMissingHive(BasePersistDocsColumnMissing):
+    pass
+
+
+class TestPersistDocsCommentOnQuotedColumnHive(BasePersistDocsCommentOnQuotedColumn):
+    pass


### PR DESCRIPTION
## Describe your changes
Adds support for the persist_docs feature in the dbt-hive adapter. Ensures table and column descriptions in dbt are actually saved as native comments in Hive.
- Added comments attribute to the HiveColumn class to support carrying comment metadata.
- Added logic to clean up single quotes ('), newlines (\n, \r), and semicolons (;) before passing comments to Hive.
- _hive_describe_row_comment: Added to parse comments from Hive's DESCRIBE output 
- _get_columns_for_catalog: Updated to fetch column and table comments for dbt docs generation.
- _table_comment_from_properties: Added to extract table-level metadata. 
- hive__alter_column_comment: Updated ALTER TABLE commands to apply column comments.
- hive__view_column_comment_list: Added macro support to handle comments for Hive views.

## Internal Jira ticket number or external issue link
https://cloudera.atlassian.net/browse/DBT-855

## Testing procedure/screenshots(if appropriate):
https://gist.github.com/MonikaK2409/fb98126fe0af664c29f9547b70026409

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have formatted my added/modified code to follow pep-8 standards
- [x] I have checked suggestions from python linter to make sure code is of good quality.